### PR TITLE
Integrate and refactor parse folder

### DIFF
--- a/src/libs/parse/validate_keys.ts
+++ b/src/libs/parse/validate_keys.ts
@@ -1,129 +1,143 @@
+import { stringSimilarity, SIMILARITY_ALGO_MAP, SIMILARITY_TYPE } from '../../libs/string_similarity';
+import { KeysDict } from '../../types';
 
-def validate_keys(
-    d_: dict[str, Any],
-    keys: Sequence[str] | KeysDict,
-    /,
-    *,
-    similarity_algo: SIMILARITY_TYPE | Callable[[str, str], float] = "jaro_winkler",
-    similarity_threshold: float = 0.85,
-    fuzzy_match: bool = True,
-    handle_unmatched: Literal["ignore", "raise", "remove", "fill", "force"] = "ignore",
-    fill_value: Any = None,
-    fill_mapping: dict[str, Any] | None = None,
-    strict: bool = False,
-) -> dict[str, Any]:
-    """
-    Validate and correct dictionary keys based on expected keys using string similarity.
+/**
+ * Validate and correct dictionary keys based on expected keys using string similarity.
+ * 
+ * @param d_ - The dictionary to validate and correct keys for.
+ * @param keys - List of expected keys or dictionary mapping keys to types.
+ * @param similarity_algo - String similarity algorithm to use or custom function.
+ * @param similarity_threshold - Minimum similarity score for fuzzy matching.
+ * @param fuzzy_match - If True, use fuzzy matching for key correction.
+ * @param handle_unmatched - Specifies how to handle unmatched keys:
+ *   - "ignore": Keep unmatched keys in output.
+ *   - "raise": Raise ValueError if unmatched keys exist.
+ *   - "remove": Remove unmatched keys from output.
+ *   - "fill": Fill unmatched keys with default value/mapping.
+ *   - "force": Combine "fill" and "remove" behaviors.
+ * @param fill_value - Default value for filling unmatched keys.
+ * @param fill_mapping - Dictionary mapping unmatched keys to default values.
+ * @param strict - If True, raise ValueError if any expected key is missing.
+ * @returns A new dictionary with validated and corrected keys.
+ * @throws ValueError - If validation fails based on specified parameters.
+ * @throws TypeError - If input types are invalid.
+ * @throws AttributeError - If key validation fails.
+ */
+export function validateKeys(
+  d_: Record<string, any>,
+  keys: string[] | KeysDict,
+  similarity_algo: SIMILARITY_TYPE | ((a: string, b: string) => number) = 'jaro_winkler',
+  similarity_threshold: number = 0.85,
+  fuzzy_match: boolean = true,
+  handle_unmatched: 'ignore' | 'raise' | 'remove' | 'fill' | 'force' = 'ignore',
+  fill_value: any = null,
+  fill_mapping: Record<string, any> | null = null,
+  strict: boolean = false
+): Record<string, any> {
+  // Input validation
+  if (typeof d_ !== 'object' || d_ === null) {
+    throw new TypeError('First argument must be a dictionary');
+  }
+  if (keys === null) {
+    throw new TypeError('Keys argument cannot be null');
+  }
+  if (similarity_threshold < 0.0 || similarity_threshold > 1.0) {
+    throw new ValueError('similarity_threshold must be between 0.0 and 1.0');
+  }
 
-    Args:
-        d_: The dictionary to validate and correct keys for.
-        keys: List of expected keys or dictionary mapping keys to types.
-        similarity_algo: String similarity algorithm to use or custom function.
-        similarity_threshold: Minimum similarity score for fuzzy matching.
-        fuzzy_match: If True, use fuzzy matching for key correction.
-        handle_unmatched: Specifies how to handle unmatched keys:
-            - "ignore": Keep unmatched keys in output.
-            - "raise": Raise ValueError if unmatched keys exist.
-            - "remove": Remove unmatched keys from output.
-            - "fill": Fill unmatched keys with default value/mapping.
-            - "force": Combine "fill" and "remove" behaviors.
-        fill_value: Default value for filling unmatched keys.
-        fill_mapping: Dictionary mapping unmatched keys to default values.
-        strict: If True, raise ValueError if any expected key is missing.
+  // Extract expected keys
+  const fields_set = Array.isArray(keys) ? new Set(keys) : new Set(Object.keys(keys));
+  if (fields_set.size === 0) {
+    return { ...d_ }; // Return copy of original if no expected keys
+  }
 
-    Returns:
-        A new dictionary with validated and corrected keys.
+  // Initialize output dictionary and tracking sets
+  const corrected_out: Record<string, any> = {};
+  const matched_expected = new Set<string>();
+  const matched_input = new Set<string>();
 
-    Raises:
-        ValueError: If validation fails based on specified parameters.
-        TypeError: If input types are invalid.
-        AttributeError: If key validation fails.
-    """
-    # Input validation
-    if not isinstance(d_, dict):
-        raise TypeError("First argument must be a dictionary")
-    if keys is None:
-        raise TypeError("Keys argument cannot be None")
-    if not 0.0 <= similarity_threshold <= 1.0:
-        raise ValueError("similarity_threshold must be between 0.0 and 1.0")
+  // Get similarity function
+  let similarity_func: (a: string, b: string) => number;
+  if (typeof similarity_algo === 'string') {
+    if (!(similarity_algo in SIMILARITY_ALGO_MAP)) {
+      throw new ValueError(`Unknown similarity algorithm: ${similarity_algo}`);
+    }
+    similarity_func = SIMILARITY_ALGO_MAP[similarity_algo];
+  } else {
+    similarity_func = similarity_algo;
+  }
 
-    # Extract expected keys
-    fields_set = set(keys) if isinstance(keys, list) else set(keys.keys())
-    if not fields_set:
-        return d_.copy()  # Return copy of original if no expected keys
+  // First pass: exact matches
+  for (const key of Object.keys(d_)) {
+    if (fields_set.has(key)) {
+      corrected_out[key] = d_[key];
+      matched_expected.add(key);
+      matched_input.add(key);
+    }
+  }
 
-    # Initialize output dictionary and tracking sets
-    corrected_out = {}
-    matched_expected = set()
-    matched_input = set()
+  // Second pass: fuzzy matching if enabled
+  if (fuzzy_match) {
+    const remaining_input = new Set(Object.keys(d_).filter(key => !matched_input.has(key)));
+    const remaining_expected = new Set(Array.from(fields_set).filter(key => !matched_expected.has(key)));
 
-    # Get similarity function
-    if isinstance(similarity_algo, str):
-        if similarity_algo not in SIMILARITY_ALGO_MAP:
-            raise ValueError(f"Unknown similarity algorithm: {similarity_algo}")
-        similarity_func = SIMILARITY_ALGO_MAP[similarity_algo]
-    else:
-        similarity_func = similarity_algo
+    for (const key of remaining_input) {
+      if (remaining_expected.size === 0) {
+        break;
+      }
 
-    # First pass: exact matches
-    for key in d_:
-        if key in fields_set:
-            corrected_out[key] = d_[key]
-            matched_expected.add(key)
-            matched_input.add(key)
+      const matches = stringSimilarity(
+        key,
+        Array.from(remaining_expected),
+        similarity_func,
+        similarity_threshold,
+        true
+      );
 
-    # Second pass: fuzzy matching if enabled
-    if fuzzy_match:
-        remaining_input = set(d_.keys()) - matched_input
-        remaining_expected = fields_set - matched_expected
+      if (matches) {
+        const match = matches;
+        corrected_out[match] = d_[key];
+        matched_expected.add(match);
+        matched_input.add(key);
+        remaining_expected.delete(match);
+      } else if (handle_unmatched === 'ignore') {
+        corrected_out[key] = d_[key];
+      }
+    }
+  }
 
-        for key in remaining_input:
-            if not remaining_expected:
-                break
+  // Handle unmatched keys based on handle_unmatched parameter
+  const unmatched_input = new Set(Object.keys(d_).filter(key => !matched_input.has(key)));
+  const unmatched_expected = new Set(Array.from(fields_set).filter(key => !matched_expected.has(key)));
 
-            matches = string_similarity(
-                key,
-                list(remaining_expected),
-                algorithm=similarity_func,
-                threshold=similarity_threshold,
-                return_most_similar=True,
-            )
+  if (handle_unmatched === 'raise' && unmatched_input.size > 0) {
+    throw new ValueError(`Unmatched keys found: ${Array.from(unmatched_input)}`);
+  } else if (handle_unmatched === 'ignore') {
+    for (const key of unmatched_input) {
+      corrected_out[key] = d_[key];
+    }
+  } else if (handle_unmatched === 'fill' || handle_unmatched === 'force') {
+    // Fill missing expected keys
+    for (const key of unmatched_expected) {
+      if (fill_mapping && key in fill_mapping) {
+        corrected_out[key] = fill_mapping[key];
+      } else {
+        corrected_out[key] = fill_value;
+      }
+    }
 
-            if matches:
-                match = matches
-                corrected_out[match] = d_[key]
-                matched_expected.add(match)
-                matched_input.add(key)
-                remaining_expected.remove(match)
-            elif handle_unmatched == "ignore":
-                corrected_out[key] = d_[key]
+    // For "fill" mode, also keep unmatched original keys
+    if (handle_unmatched === 'fill') {
+      for (const key of unmatched_input) {
+        corrected_out[key] = d_[key];
+      }
+    }
+  }
 
-    # Handle unmatched keys based on handle_unmatched parameter
-    unmatched_input = set(d_.keys()) - matched_input
-    unmatched_expected = fields_set - matched_expected
+  // Check strict mode
+  if (strict && unmatched_expected.size > 0) {
+    throw new ValueError(`Missing required keys: ${Array.from(unmatched_expected)}`);
+  }
 
-    if handle_unmatched == "raise" and unmatched_input:
-        raise ValueError(f"Unmatched keys found: {unmatched_input}")
-
-    elif handle_unmatched == "ignore":
-        for key in unmatched_input:
-            corrected_out[key] = d_[key]
-
-    elif handle_unmatched in ("fill", "force"):
-        # Fill missing expected keys
-        for key in unmatched_expected:
-            if fill_mapping and key in fill_mapping:
-                corrected_out[key] = fill_mapping[key]
-            else:
-                corrected_out[key] = fill_value
-
-        # For "fill" mode, also keep unmatched original keys
-        if handle_unmatched == "fill":
-            for key in unmatched_input:
-                corrected_out[key] = d_[key]
-
-    # Check strict mode
-    if strict and unmatched_expected:
-        raise ValueError(f"Missing required keys: {unmatched_expected}")
-
-    return corrected_out
+  return corrected_out;
+}

--- a/src/libs/parse/validate_mapping.ts
+++ b/src/libs/parse/validate_mapping.ts
@@ -1,95 +1,92 @@
+import { toJson, toDict } from './to_json';
+import { validateKeys } from './validate_keys';
+import { SIMILARITY_TYPE } from '../../libs/string_similarity';
+import { KeysDict } from '../../types';
 
-def validate_mapping(
-    d: Any,
-    keys: Sequence[str] | KeysDict,
-    /,
-    *,
-    similarity_algo: SIMILARITY_TYPE | Callable[[str, str], float] = "jaro_winkler",
-    similarity_threshold: float = 0.85,
-    fuzzy_match: bool = True,
-    handle_unmatched: Literal["ignore", "raise", "remove", "fill", "force"] = "ignore",
-    fill_value: Any = None,
-    fill_mapping: dict[str, Any] | None = None,
-    strict: bool = False,
-    suppress_conversion_errors: bool = False,
-) -> dict[str, Any]:
-    """
-    Validate and correct any input into a dictionary with expected keys.
+/**
+ * Validate and correct any input into a dictionary with expected keys.
+ * 
+ * @param d - Input to validate. Can be:
+ *   - Dictionary
+ *   - JSON string or markdown code block
+ *   - XML string
+ *   - Object with to_dict/model_dump method
+ *   - Any type convertible to dictionary
+ * @param keys - List of expected keys or dictionary mapping keys to types.
+ * @param similarity_algo - String similarity algorithm or custom function.
+ * @param similarity_threshold - Minimum similarity score for fuzzy matching.
+ * @param fuzzy_match - If True, use fuzzy matching for key correction.
+ * @param handle_unmatched - How to handle unmatched keys:
+ *   - "ignore": Keep unmatched keys
+ *   - "raise": Raise error for unmatched keys
+ *   - "remove": Remove unmatched keys
+ *   - "fill": Fill missing keys with default values
+ *   - "force": Combine "fill" and "remove" behaviors
+ * @param fill_value - Default value for filling unmatched keys.
+ * @param fill_mapping - Dictionary mapping keys to default values.
+ * @param strict - Raise error if any expected key is missing.
+ * @param suppress_conversion_errors - Return empty dict on conversion errors.
+ * @returns Validated and corrected dictionary.
+ * @throws ValueError - If input cannot be converted or validation fails.
+ * @throws TypeError - If input types are invalid.
+ */
+export function validateMapping(
+  d: any,
+  keys: string[] | KeysDict,
+  similarity_algo: SIMILARITY_TYPE | ((a: string, b: string) => number) = 'jaro_winkler',
+  similarity_threshold: number = 0.85,
+  fuzzy_match: boolean = true,
+  handle_unmatched: 'ignore' | 'raise' | 'remove' | 'fill' | 'force' = 'ignore',
+  fill_value: any = null,
+  fill_mapping: Record<string, any> | null = null,
+  strict: boolean = false,
+  suppress_conversion_errors: boolean = false
+): Record<string, any> {
+  if (d === null || d === undefined) {
+    throw new TypeError("Input cannot be null or undefined");
+  }
 
-    Args:
-        d: Input to validate. Can be:
-            - Dictionary
-            - JSON string or markdown code block
-            - XML string
-            - Object with to_dict/model_dump method
-            - Any type convertible to dictionary
-        keys: List of expected keys or dictionary mapping keys to types.
-        similarity_algo: String similarity algorithm or custom function.
-        similarity_threshold: Minimum similarity score for fuzzy matching.
-        fuzzy_match: If True, use fuzzy matching for key correction.
-        handle_unmatched: How to handle unmatched keys:
-            - "ignore": Keep unmatched keys
-            - "raise": Raise error for unmatched keys
-            - "remove": Remove unmatched keys
-            - "fill": Fill missing keys with default values
-            - "force": Combine "fill" and "remove" behaviors
-        fill_value: Default value for filling unmatched keys.
-        fill_mapping: Dictionary mapping keys to default values.
-        strict: Raise error if any expected key is missing.
-        suppress_conversion_errors: Return empty dict on conversion errors.
+  // Try converting to dictionary
+  let dictInput: Record<string, any>;
+  try {
+    if (typeof d === 'string') {
+      // First try toJson for JSON strings and code blocks
+      try {
+        const jsonResult = toJson(d);
+        dictInput = Array.isArray(jsonResult) ? jsonResult[0] : jsonResult;
+      } catch {
+        // Fall back to toDict for other string formats
+        dictInput = toDict(d, { strType: 'json', fuzzyParse: true, suppress: true });
+      }
+    } else {
+      dictInput = toDict(d, { useModelDump: true, fuzzyParse: true, suppress: true });
+    }
 
-    Returns:
-        Validated and corrected dictionary.
+    if (typeof dictInput !== 'object' || dictInput === null) {
+      if (suppress_conversion_errors) {
+        dictInput = {};
+      } else {
+        throw new ValueError(`Failed to convert input to dictionary: ${typeof dictInput}`);
+      }
+    }
+  } catch (e) {
+    if (suppress_conversion_errors) {
+      dictInput = {};
+    } else {
+      throw new ValueError(`Failed to convert input to dictionary: ${e}`);
+    }
+  }
 
-    Raises:
-        ValueError: If input cannot be converted or validation fails.
-        TypeError: If input types are invalid.
-    """
-    if d is None:
-        raise TypeError("Input cannot be None")
-
-    # Try converting to dictionary
-    try:
-        if isinstance(d, str):
-            # First try to_json for JSON strings and code blocks
-            try:
-                json_result = to_json(d)
-                dict_input = (
-                    json_result[0] if isinstance(json_result, list) else json_result
-                )
-            except Exception:
-                # Fall back to to_dict for other string formats
-                dict_input = to_dict(
-                    d, str_type="json", fuzzy_parse=True, suppress=True
-                )
-        else:
-            dict_input = to_dict(
-                d, use_model_dump=True, fuzzy_parse=True, suppress=True
-            )
-
-        if not isinstance(dict_input, dict):
-            if suppress_conversion_errors:
-                dict_input = {}
-            else:
-                raise ValueError(
-                    f"Failed to convert input to dictionary: {type(dict_input)}"
-                )
-
-    except Exception as e:
-        if suppress_conversion_errors:
-            dict_input = {}
-        else:
-            raise ValueError(f"Failed to convert input to dictionary: {e}")
-
-    # Validate the dictionary
-    return validate_keys(
-        dict_input,
-        keys,
-        similarity_algo=similarity_algo,
-        similarity_threshold=similarity_threshold,
-        fuzzy_match=fuzzy_match,
-        handle_unmatched=handle_unmatched,
-        fill_value=fill_value,
-        fill_mapping=fill_mapping,
-        strict=strict,
-    )
+  // Validate the dictionary
+  return validateKeys(
+    dictInput,
+    keys,
+    similarity_algo,
+    similarity_threshold,
+    fuzzy_match,
+    handle_unmatched,
+    fill_value,
+    fill_mapping,
+    strict
+  );
+}

--- a/src/libs/parse/xml_parser.ts
+++ b/src/libs/parse/xml_parser.ts
@@ -1,135 +1,62 @@
+import * as xml2js from 'xml2js';
+import * as xmlbuilder from 'xmlbuilder';
 
-def xml_to_dict(
-    xml_string: str,
-    /,
-    suppress=False,
-    remove_root: bool = True,
-    root_tag: str = None,
-) -> dict[str, Any]:
-    """
-    Parse an XML string into a nested dictionary structure.
+/**
+ * Parse an XML string into a nested dictionary structure.
+ * 
+ * This function converts an XML string into a dictionary where:
+ * - Element tags become dictionary keys
+ * - Text content is assigned directly to the tag key if there are no children
+ * - Attributes are stored in a '@attributes' key
+ * - Multiple child elements with the same tag are stored as lists
+ * 
+ * @param xmlString - The XML string to parse.
+ * @param suppress - If true, suppresses errors and returns an empty object on failure.
+ * @param removeRoot - If true, removes the root element from the resulting dictionary.
+ * @param rootTag - The root tag to remove if removeRoot is true.
+ * @returns A dictionary representation of the XML structure.
+ * @throws Error if the XML is malformed or parsing fails and suppress is false.
+ */
+export function xmlToDict(
+  xmlString: string,
+  suppress: boolean = false,
+  removeRoot: boolean = true,
+  rootTag: string | null = null
+): Record<string, any> {
+  try {
+    const parser = new xml2js.Parser({ explicitArray: false, mergeAttrs: true });
+    const result = parser.parseStringPromise(xmlString);
+    if (removeRoot && (rootTag || 'root') in result) {
+      return result[rootTag || 'root'];
+    }
+    return result;
+  } catch (error) {
+    if (!suppress) {
+      throw error;
+    }
+    return {};
+  }
+}
 
-    This function converts an XML string into a dictionary where:
-    - Element tags become dictionary keys
-    - Text content is assigned directly to the tag key if there are no children
-    - Attributes are stored in a '@attributes' key
-    - Multiple child elements with the same tag are stored as lists
-
-    Args:
-        xml_string: The XML string to parse.
-
-    Returns:
-        A dictionary representation of the XML structure.
-
-    Raises:
-        ValueError: If the XML is malformed or parsing fails.
-    """
-    try:
-        a = XMLParser(xml_string).parse()
-        if remove_root and (root_tag or "root") in a:
-            a = a[root_tag or "root"]
-        return a
-    except ValueError as e:
-        if not suppress:
-            raise e
-
-
-def dict_to_xml(data: dict, /, root_tag: str = "root") -> str:
-
-    root = ET.Element(root_tag)
-
-    def convert(dict_obj: dict, parent: Any) -> None:
-        for key, val in dict_obj.items():
-            if isinstance(val, dict):
-                element = ET.SubElement(parent, key)
-                convert(dict_obj=val, parent=element)
-            else:
-                element = ET.SubElement(parent, key)
-                element.text = str(object=val)
-
-    convert(dict_obj=data, parent=root)
-    return ET.tostring(root, encoding="unicode")
-
-
-class XMLParser:
-    def __init__(self, xml_string: str):
-        self.xml_string = xml_string.strip()
-        self.index = 0
-
-    def parse(self) -> dict[str, Any]:
-        """Parse the XML string and return the root element as a dictionary."""
-        return self._parse_element()
-
-    def _parse_element(self) -> dict[str, Any]:
-        """Parse a single XML element and its children."""
-        self._skip_whitespace()
-        if self.xml_string[self.index] != "<":
-            raise ValueError(f"Expected '<', found '{self.xml_string[self.index]}'")
-
-        tag, attributes = self._parse_opening_tag()
-        children: dict[str, str | list | dict] = {}
-        text = ""
-
-        while self.index < len(self.xml_string):
-            self._skip_whitespace()
-            if self.xml_string.startswith("</", self.index):
-                closing_tag = self._parse_closing_tag()
-                if closing_tag != tag:
-                    raise ValueError(f"Mismatched tags: '{tag}' and '{closing_tag}'")
-                break
-            elif self.xml_string.startswith("<", self.index):
-                child = self._parse_element()
-                child_tag, child_data = next(iter(child.items()))
-                if child_tag in children:
-                    if not isinstance(children[child_tag], list):
-                        children[child_tag] = [children[child_tag]]
-                    children[child_tag].append(child_data)
-                else:
-                    children[child_tag] = child_data
-            else:
-                text += self._parse_text()
-
-        result: dict[str, Any] = {}
-        if attributes:
-            result["@attributes"] = attributes
-        if children:
-            result.update(children)
-        elif text.strip():
-            result = text.strip()
-
-        return {tag: result}
-
-    def _parse_opening_tag(self) -> tuple[str, dict[str, str]]:
-        """Parse an opening XML tag and its attributes."""
-        match = re.match(
-            r'<(\w+)((?:\s+\w+="[^"]*")*)\s*/?>',
-            self.xml_string[self.index :],  # noqa
-        )
-        if not match:
-            raise ValueError("Invalid opening tag")
-        self.index += match.end()
-        tag = match.group(1)
-        attributes = dict(re.findall(r'(\w+)="([^"]*)"', match.group(2)))
-        return tag, attributes
-
-    def _parse_closing_tag(self) -> str:
-        """Parse a closing XML tag."""
-        match = re.match(r"</(\w+)>", self.xml_string[self.index :])  # noqa
-        if not match:
-            raise ValueError("Invalid closing tag")
-        self.index += match.end()
-        return match.group(1)
-
-    def _parse_text(self) -> str:
-        """Parse text content between XML tags."""
-        start = self.index
-        while self.index < len(self.xml_string) and self.xml_string[self.index] != "<":
-            self.index += 1
-        return self.xml_string[start : self.index]  # noqa
-
-    def _skip_whitespace(self) -> None:
-        """Skip any whitespace characters at the current parsing position."""
-        p_ = len(self.xml_string[self.index :])  # noqa
-        m_ = len(self.xml_string[self.index :].lstrip())  # noqa
-
-        self.index += p_ - m_
+/**
+ * Convert a dictionary to an XML string.
+ * 
+ * @param data - The dictionary to convert to XML.
+ * @param rootTag - The root tag for the XML document.
+ * @returns The XML string representation of the dictionary.
+ */
+export function dictToXml(data: Record<string, any>, rootTag: string = 'root'): string {
+  const root = xmlbuilder.create(rootTag);
+  function convert(dictObj: Record<string, any>, parent: xmlbuilder.XMLElement) {
+    for (const [key, val] of Object.entries(dictObj)) {
+      if (typeof val === 'object' && !Array.isArray(val)) {
+        const element = parent.ele(key);
+        convert(val, element);
+      } else {
+        parent.ele(key, {}, String(val));
+      }
+    }
+  }
+  convert(data, root);
+  return root.end({ pretty: true });
+}


### PR DESCRIPTION
Convert files under `src/libs/parse` to proper TypeScript with correct imports and type annotations.

* **`src/libs/parse/validate_boolean.ts`**
  - Rewrite in TypeScript with proper types and interfaces.
  - Replace Python-style docstrings with TSDoc comments.
  - Implement `validateBoolean` function in TypeScript.

* **`src/libs/parse/validate_keys.ts`**
  - Rewrite in TypeScript with proper types and interfaces.
  - Replace Python-style docstrings with TSDoc comments.
  - Implement `validateKeys` function in TypeScript.

* **`src/libs/parse/validate_mapping.ts`**
  - Rewrite in TypeScript with proper types and interfaces.
  - Replace Python-style docstrings with TSDoc comments.
  - Implement `validateMapping` function in TypeScript.

* **`src/libs/parse/xml_parser.ts`**
  - Rewrite in TypeScript with proper types and interfaces.
  - Replace Python-style docstrings with TSDoc comments.
  - Implement `xmlToDict` and `dictToXml` functions in TypeScript.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ohdearquant/lion-ts/pull/1?shareId=e7c270c5-c6ad-4fb4-bf0d-7824a13d63dd).