### PR TITLE
Translate core_py files to TypeScript

### DIFF
--- a/src/core/_class_registry.ts
+++ b/src/core/_class_registry.ts
@@ -1,0 +1,44 @@
+import * as path from 'path';
+import { getClassFileRegistry, getClassObjects } from 'lion/libs/utils';
+
+type ClassType<T> = new (...args: any[]) => T;
+
+interface ClassRegistry<T> {
+  [key: string]: ClassType<T>;
+}
+
+interface ClassFileRegistry {
+  [key: string]: string;
+}
+
+const LION_CLASS_REGISTRY: ClassRegistry<any> = {};
+let LION_CLASS_FILE_REGISTRY: ClassFileRegistry = {};
+
+const patternList = [
+  'lion/core/generic',
+  'lion/core/communication',
+  'lion/core/action',
+  'lion/core/session',
+  'lion/core/forms',
+];
+
+if (Object.keys(LION_CLASS_FILE_REGISTRY).length === 0) {
+  const scriptPath = path.resolve(__filename);
+  const scriptDir = path.dirname(scriptPath);
+
+  LION_CLASS_FILE_REGISTRY = getClassFileRegistry(scriptDir, patternList);
+}
+
+export function getClass<T>(className: string): ClassType<T> {
+  if (LION_CLASS_REGISTRY[className]) {
+    return LION_CLASS_REGISTRY[className];
+  }
+
+  try {
+    const foundClassFilepath = LION_CLASS_FILE_REGISTRY[className];
+    const foundClassDict = getClassObjects(foundClassFilepath);
+    return foundClassDict[className];
+  } catch (e) {
+    throw new Error(`Unable to find class ${className}: ${e}`);
+  }
+}

--- a/src/core/action/action_manager.ts
+++ b/src/core/action/action_manager.ts
@@ -1,0 +1,167 @@
+import { LogManager } from 'lion/core/generic/log_manager';
+import { toDict, toList } from 'lion/libs/parse';
+import { ActionRequest } from 'lion/core/communication/action_request';
+import { FunctionCalling } from 'lion/core/action/function_calling';
+import { Tool, funcToTool } from 'lion/core/action/tool';
+import { ActionRequestModel } from 'lion/protocols/operatives/action';
+
+type Any = any;
+type Functool = Tool | ((...args: any[]) => Any);
+type FindableTool = Functool | string;
+type InputtableTool = { [key: string]: Any } | boolean | FindableTool;
+type ToolType = FindableTool | FindableTool[] | InputtableTool;
+
+export class ActionManager {
+  registry: { [key: string]: Tool };
+  logger: LogManager;
+
+  constructor(registry: { [key: string]: Tool } | null = null, logger: LogManager | null = null) {
+    this.registry = registry || {};
+    this.logger = logger || new LogManager();
+  }
+
+  contains(tool: FindableTool): boolean {
+    if (tool instanceof Tool) {
+      return tool.functionName in this.registry;
+    } else if (typeof tool === 'string') {
+      return tool in this.registry;
+    } else if (typeof tool === 'function') {
+      return tool.name in this.registry;
+    }
+    return false;
+  }
+
+  registerTool(tool: Functool, update: boolean = false): void {
+    if (!update && this.contains(tool)) {
+      let name: string | undefined;
+      if (tool instanceof Tool) {
+        name = tool.functionName;
+      } else if (typeof tool === 'function') {
+        name = tool.name;
+      }
+      throw new Error(`Tool ${name} is already registered.`);
+    }
+
+    if (typeof tool === 'function') {
+      tool = funcToTool(tool)[0];
+    }
+    if (!(tool instanceof Tool)) {
+      throw new TypeError('Please register a Tool object or callable.');
+    }
+
+    this.registry[tool.functionName] = tool;
+  }
+
+  registerTools(tools: Functool[] | Functool, update: boolean = false): void {
+    const toolsList = Array.isArray(tools) ? tools : [tools];
+    toolsList.forEach(tool => this.registerTool(tool, update));
+  }
+
+  matchTool(funcCall: any): FunctionCalling {
+    if (Array.isArray(funcCall)) {
+      return this.matchToolTuple(funcCall);
+    } else if (typeof funcCall === 'object') {
+      return this.matchToolDict(funcCall);
+    } else if (funcCall instanceof ActionRequest || funcCall instanceof ActionRequestModel) {
+      return this.matchToolActionRequest(funcCall);
+    } else if (typeof funcCall === 'string') {
+      return this.matchToolString(funcCall);
+    } else {
+      throw new TypeError(`Unsupported type ${typeof funcCall}`);
+    }
+  }
+
+  private matchToolTuple(funcCall: [string, any]): FunctionCalling {
+    if (funcCall.length === 2) {
+      const [functionName, arguments_] = funcCall;
+      const tool = this.registry[functionName];
+      if (!tool) {
+        throw new Error(`Function ${functionName} is not registered`);
+      }
+      return new FunctionCalling(tool, arguments_);
+    } else {
+      throw new Error(`Invalid function call ${funcCall}`);
+    }
+  }
+
+  private matchToolDict(funcCall: { [key: string]: any }): FunctionCalling {
+    if (funcCall.function && funcCall.arguments) {
+      const { function: functionName, arguments: arguments_ } = funcCall;
+      const tool = this.registry[functionName];
+      if (!tool) {
+        throw new Error(`Function ${functionName} is not registered`);
+      }
+      return new FunctionCalling(tool, arguments_);
+    } else {
+      throw new Error(`Invalid function call ${funcCall}`);
+    }
+  }
+
+  private matchToolActionRequest(funcCall: ActionRequest | ActionRequestModel): FunctionCalling {
+    const tool = this.registry[funcCall.function];
+    if (!tool) {
+      throw new Error(`Function ${funcCall.function} is not registered.`);
+    }
+    return new FunctionCalling(tool, funcCall.arguments);
+  }
+
+  private matchToolString(funcCall: string): FunctionCalling {
+    let call: any;
+    try {
+      call = toDict(funcCall, 'json', true);
+    } catch (e) {
+      throw new Error(`Invalid function call ${funcCall}`);
+    }
+
+    if (typeof call === 'object') {
+      return this.matchTool(call);
+    } else {
+      throw new Error(`Invalid function call ${funcCall}`);
+    }
+  }
+
+  async invoke(funcCall: { [key: string]: any } | string | ActionRequest, logManager: LogManager | null = null): Promise<any> {
+    const functionCalling = this.matchTool(funcCall);
+    const result = await functionCalling.invoke();
+    await this.logger.alog(functionCalling.toLog());
+    return result;
+  }
+
+  get schemaList(): { [key: string]: any }[] {
+    return Object.values(this.registry).map(tool => tool.schema_);
+  }
+
+  getToolSchema(tools: ToolType = false, ...kwargs: any[]): { [key: string]: any } {
+    let toolKwarg: { [key: string]: any };
+    if (typeof tools === 'boolean') {
+      toolKwarg = tools ? { tools: this.schemaList } : {};
+    } else {
+      toolKwarg = { tools: this._getToolSchema(tools) };
+    }
+    return { ...toolKwarg, ...kwargs };
+  }
+
+  private _getToolSchema(tool: any): { [key: string]: any } | { [key: string]: any }[] {
+    if (typeof tool === 'object') {
+      return tool;
+    } else if (typeof tool === 'function') {
+      const name = tool.name;
+      if (name in this.registry) {
+        return this.registry[name].schema_;
+      } else {
+        throw new Error(`Tool ${name} is not registered.`);
+      }
+    } else if (tool instanceof Tool || typeof tool === 'string') {
+      const name = tool instanceof Tool ? tool.functionName : tool;
+      if (name in this.registry) {
+        return this.registry[name].schema_;
+      } else {
+        throw new Error(`Tool ${name} is not registered.`);
+      }
+    } else if (Array.isArray(tool)) {
+      return tool.map(t => this._getToolSchema(t));
+    } else {
+      throw new TypeError(`Unsupported type ${typeof tool}`);
+    }
+  }
+}

--- a/src/core/action/base.ts
+++ b/src/core/action/base.ts
@@ -1,0 +1,59 @@
+import { Element, Log } from 'lion/core/generic';
+import { Any, Enum, NoReturn, PrivateAttr, override } from 'lion/core/typing';
+import { Settings, TimedFuncCallConfig } from 'lion/settings';
+
+enum EventStatus {
+  PENDING = 'pending',
+  PROCESSING = 'processing',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
+class ObservableAction extends Element {
+  status: EventStatus = EventStatus.PENDING;
+  executionTime: number | null = null;
+  executionResponse: Any = null;
+  executionError: string | null = null;
+  private _timedConfig: TimedFuncCallConfig | null = null;
+  private _contentFields: string[] = ['executionResponse'];
+
+  @override
+  constructor(timedConfig: Record<string, any> | TimedFuncCallConfig | null, ...kwargs: any[]) {
+    super();
+    if (timedConfig === null) {
+      this._timedConfig = Settings.Config.TIMED_CALL;
+    } else {
+      if (timedConfig instanceof TimedFuncCallConfig) {
+        timedConfig = timedConfig.toDict();
+      }
+      if (typeof timedConfig === 'object') {
+        timedConfig = { ...timedConfig, ...kwargs };
+      }
+      this._timedConfig = new TimedFuncCallConfig(timedConfig);
+    }
+  }
+
+  toLog(): Log {
+    const dict_ = this.toDict();
+    dict_['status'] = this.status;
+    const content = this._contentFields.reduce((acc, field) => {
+      if (dict_[field] !== undefined) {
+        acc[field] = dict_[field];
+      }
+      return acc;
+    }, {} as Record<string, any>);
+    const loginfo = Object.keys(dict_).reduce((acc, key) => {
+      if (!this._contentFields.includes(key)) {
+        acc[key] = dict_[key];
+      }
+      return acc;
+    }, {} as Record<string, any>);
+    return new Log(content, loginfo);
+  }
+
+  static fromDict(data: Record<string, any>, ...kwargs: any[]): NoReturn {
+    throw new Error("An event cannot be recreated. Once it's done, it's done.");
+  }
+}
+
+export { ObservableAction, EventStatus };

--- a/src/core/action/function_calling.ts
+++ b/src/core/action/function_calling.ts
@@ -1,0 +1,81 @@
+import * as asyncio from 'asyncio';
+import { override } from 'lion/core/typing';
+import { Field, PrivateAttr } from 'lion/core/typing';
+import { CallDecorator as cd, tcall } from 'lion/libs/func';
+import { TimedFuncCallConfig } from 'lion/settings';
+import { EventStatus, ObservableAction } from './base';
+import { Tool } from './tool';
+
+type Any = any;
+
+class FunctionCalling extends ObservableAction {
+  funcTool: Tool | null = Field(default=null, exclude=true);
+  private _contentFields: string[] = ['executionResponse', 'arguments', 'function'];
+  arguments: { [key: string]: Any } | null = null;
+  function: string | null = null;
+
+  constructor(
+    funcTool: Tool,
+    arguments: { [key: string]: Any },
+    timedConfig: { [key: string]: Any } | TimedFuncCallConfig = null,
+    ...kwargs: Any[]
+  ) {
+    super(timedConfig, ...kwargs);
+    this.funcTool = funcTool;
+    this.arguments = arguments || {};
+    this.function = this.funcTool.functionName;
+  }
+
+  @override
+  async invoke(): Promise<Any> {
+    const start = asyncio.get_event_loop().time();
+    try {
+      const _inner = cd.pre_post_process(
+        async (kwargs: { [key: string]: Any }) => {
+          const config = this._timedConfig.toDict();
+          const result = await tcall(this.funcTool!.function, { ...kwargs, ...config });
+          if (Array.isArray(result) && result.length === 2) {
+            return result[0];
+          }
+          return result;
+        },
+        this.funcTool!.preProcessor,
+        this.funcTool!.postProcessor,
+        this.funcTool!.preProcessorKwargs || {},
+        this.funcTool!.postProcessorKwargs || {}
+      );
+
+      const result = await _inner(this.arguments);
+      this.executionResponse = result;
+      this.executionTime = asyncio.get_event_loop().time() - start;
+      this.status = EventStatus.COMPLETED;
+
+      if (this.funcTool!.parser !== null) {
+        if (asyncio.iscoroutinefunction(this.funcTool!.parser)) {
+          result = await this.funcTool!.parser(result);
+        } else {
+          result = this.funcTool!.parser(result);
+        }
+      }
+      return result;
+    } catch (e) {
+      this.status = EventStatus.FAILED;
+      this.executionError = e.toString();
+      this.executionTime = asyncio.get_event_loop().time() - start;
+      return null;
+    }
+  }
+
+  toString(): string {
+    return `${this.funcTool!.functionName}(${JSON.stringify(this.arguments)})`;
+  }
+
+  toJSON(): string {
+    return JSON.stringify({
+      function: this.funcTool!.functionName,
+      arguments: this.arguments
+    });
+  }
+}
+
+export { FunctionCalling };

--- a/src/core/action/tool.ts
+++ b/src/core/action/tool.ts
@@ -1,0 +1,118 @@
+import { Element } from 'lion/core/generic/element';
+import { Any, Field, Literal, override } from 'lion/core/typing';
+import { functionToSchema, toList } from 'lion/libs/parse';
+
+type Callable = (...args: any[]) => Any;
+
+class Tool extends Element {
+  function: Callable = Field(
+    {
+      description: 'The callable function of the tool.',
+    }
+  );
+  schema_: { [key: string]: Any } | null = Field(
+    {
+      default: null,
+      description: 'Schema of the function in OpenAI format.',
+    }
+  );
+  preProcessor: Callable | null = Field(
+    {
+      default: null,
+      description: 'Function to preprocess input arguments.',
+    }
+  );
+  preProcessorKwargs: { [key: string]: Any } | null = Field(
+    {
+      default: null,
+      description: 'Keyword arguments for the pre-processor.',
+    }
+  );
+  postProcessor: Callable | null = Field(
+    {
+      default: null,
+      description: 'Function to post-process the result.',
+    }
+  );
+  postProcessorKwargs: { [key: string]: Any } | null = Field(
+    {
+      default: null,
+      description: 'Keyword arguments for the post-processor.',
+    }
+  );
+  parser: Callable | null = Field(
+    {
+      default: null,
+      description: 'Function to parse result to JSON serializable format.',
+    }
+  );
+
+  @override
+  constructor(data: { [key: string]: Any }) {
+    super(data);
+    if (this.schema_ === null) {
+      this.schema_ = functionToSchema(this.function);
+    }
+  }
+
+  @Field.Validator('function')
+  static validateFunction(value: Any): Callable {
+    if (typeof value !== 'function') {
+      throw new Error('Function must be callable.');
+    }
+    if (!value.name) {
+      throw new Error('Function must have a name.');
+    }
+    return value;
+  }
+
+  @Field.Serializer(
+    'function',
+    'preProcessor',
+    'postProcessor',
+    'parser',
+    'preProcessorKwargs',
+    'postProcessorKwargs'
+  )
+  static serializeField(value: Any): string | null {
+    if (typeof value === 'function') {
+      return value.name;
+    } else if (typeof value === 'object') {
+      return JSON.stringify(value);
+    }
+    return null;
+  }
+
+  get functionName(): string {
+    return this.schema_!['function']['name'];
+  }
+
+  @override
+  toString(): string {
+    const timestampStr = new Date(this.timestamp * 1000).toISOString().slice(0, 16);
+    return `${this.className()}(ln_id=${this.ln_id.slice(0, 6)}.., timestamp=${timestampStr}), schema_=${JSON.stringify(this.schema_, null, 4)}`;
+  }
+}
+
+function funcToTool(
+  func_: Callable | Callable[],
+  parser: Callable | Callable[] | null = null,
+  docstringStyle: Literal<'google', 'rest'> = 'google',
+  ...kwargs: Any[]
+): Tool[] {
+  const funcs = toList(func_);
+  const parsers = toList(parser);
+
+  if (parser && funcs.length !== parsers.length) {
+    throw new Error('Length of parser must match length of func');
+  }
+
+  return funcs.map((func, idx) => new Tool({
+    function: func,
+    schema_: functionToSchema(func, { style: docstringStyle }),
+    parser: parser ? parsers[idx] : null,
+    ...kwargs,
+  }));
+}
+
+export { Tool, funcToTool };

--- a/src/core/communication/action_request.ts
+++ b/src/core/communication/action_request.ts
@@ -1,0 +1,88 @@
+import { ID, Any, LnID, Note } from '../../core/typing';
+import { toDict } from '../../libs/parse';
+import { copy } from '../../libs/utils';
+import { MessageFlag, MessageRole, RoledMessage } from './message';
+
+function prepareActionRequest(functionName: string | Function, arguments: Record<string, any>): Note {
+    let args = copy(arguments);
+    if (typeof arguments !== 'object') {
+        try {
+            arguments = toDict(args, { fuzzyParse: true, strType: 'json', suppress: true });
+            if (!arguments) {
+                arguments = toDict(args, { strType: 'xml', suppress: true });
+            }
+            if (!arguments || typeof arguments !== 'object') {
+                throw new Error();
+            }
+        } catch (error) {
+            throw new Error('Arguments must be a dictionary.');
+        }
+    }
+    return new Note({
+        action_request: {
+            function: functionName,
+            arguments: arguments
+        }
+    });
+}
+
+export class ActionRequest extends RoledMessage {
+    constructor(
+        functionName: string | Function | MessageFlag,
+        arguments: Record<string, any> | MessageFlag,
+        sender: ID.Ref | MessageFlag = null,
+        recipient: ID.Ref | MessageFlag = null,
+        protectedInitParams: Record<string, any> = null
+    ) {
+        const messageFlags = [functionName, arguments, sender, recipient];
+
+        if (messageFlags.every(flag => flag === MessageFlag.MESSAGE_LOAD)) {
+            protectedInitParams = protectedInitParams || {};
+            super(protectedInitParams);
+            return;
+        }
+
+        if (messageFlags.every(flag => flag === MessageFlag.MESSAGE_CLONE)) {
+            super({ role: MessageRole.ASSISTANT });
+            return;
+        }
+
+        functionName = typeof functionName === 'function' ? functionName.name : functionName;
+
+        super({
+            role: MessageRole.ASSISTANT,
+            content: prepareActionRequest(functionName, arguments),
+            sender: sender,
+            recipient: recipient
+        });
+    }
+
+    get actionResponseId(): LnID | null {
+        return this.content.get('action_response_id', null);
+    }
+
+    get isResponded(): boolean {
+        return this.actionResponseId !== null;
+    }
+
+    get request(): Record<string, any> {
+        const request = copy(this.content.get('action_request', {}));
+        delete request.output;
+        return request;
+    }
+
+    get arguments(): Record<string, any> {
+        return this.request.arguments || {};
+    }
+
+    get function(): string {
+        return this.request.function || '';
+    }
+
+    protected _formatContent(): Record<string, any> {
+        return {
+            role: this.role.value,
+            content: this.request
+        };
+    }
+}

--- a/src/core/communication/action_response.ts
+++ b/src/core/communication/action_response.ts
@@ -1,0 +1,72 @@
+import { ID, Any, Note } from '../../core/typing';
+import { copy } from '../../libs/utils';
+import { ActionRequest } from './action_request';
+import { MessageFlag, MessageRole, RoledMessage } from './message';
+
+function prepareActionResponseContent(actionRequest: ActionRequest, output: Any): Note {
+    return new Note({
+        action_request_id: actionRequest.ln_id,
+        action_response: {
+            function: actionRequest.function,
+            arguments: actionRequest.arguments,
+            output: output
+        }
+    });
+}
+
+export class ActionResponse extends RoledMessage {
+    constructor(
+        actionRequest: ID<ActionRequest>,
+        output: Any = null,
+        protectedInitParams: Record<string, any> = null
+    ) {
+        const messageFlags = [actionRequest, output];
+
+        if (messageFlags.every(flag => flag === MessageFlag.MESSAGE_LOAD)) {
+            protectedInitParams = protectedInitParams || {};
+            super(protectedInitParams);
+            return;
+        }
+
+        if (messageFlags.every(flag => flag === MessageFlag.MESSAGE_CLONE)) {
+            super({ role: MessageRole.ASSISTANT });
+            return;
+        }
+
+        super({
+            role: MessageRole.ASSISTANT,
+            recipient: actionRequest.sender,
+            sender: actionRequest.recipient,
+            content: prepareActionResponseContent(actionRequest, output)
+        });
+
+        actionRequest.content.action_response_id = this.ln_id;
+    }
+
+    get function(): string {
+        return copy(this.content.get(['action_response', 'function']));
+    }
+
+    get arguments(): Record<string, any> {
+        return copy(this.content.get(['action_response', 'arguments']));
+    }
+
+    get output(): Any {
+        return this.content.get(['action_response', 'output']);
+    }
+
+    get response(): Record<string, any> {
+        return copy(this.content.get('action_response', {}));
+    }
+
+    get actionRequestId(): ID<ActionRequest> | null {
+        return copy(this.content.get('action_request_id', null));
+    }
+
+    protected _formatContent(): Record<string, any> {
+        return {
+            role: this.role.value,
+            content: this.response
+        };
+    }
+}

--- a/src/core/communication/assistant_response.ts
+++ b/src/core/communication/assistant_response.ts
@@ -1,0 +1,77 @@
+import { ID, Any, BaseModel, JsonValue, Note } from '../../core/typing';
+import { toStr } from '../../libs/parse';
+import { copy } from '../../libs/utils';
+import { MessageFlag, MessageRole, RoledMessage } from './message';
+
+function prepareAssistantResponse(assistantResponse: BaseModel | BaseModel[] | Record<string, any> | string | Any): Note {
+    const content = new Note();
+    if (assistantResponse) {
+        if (assistantResponse instanceof BaseModel) {
+            content['assistant_response'] = assistantResponse.choices[0].message.content || '';
+            content['model_response'] = assistantResponse.modelDump({ excludeNone: true, excludeUnset: true });
+        } else if (Array.isArray(assistantResponse)) {
+            const msg = assistantResponse.map(i => i.choices[0].delta.content || '').join('');
+            content['assistant_response'] = msg;
+            content['model_response'] = assistantResponse.map(i => i.modelDump({ excludeNone: true, excludeUnset: true }));
+        } else if (typeof assistantResponse === 'object' && 'content' in assistantResponse) {
+            content['assistant_response'] = assistantResponse['content'];
+        } else if (typeof assistantResponse === 'string') {
+            content['assistant_response'] = assistantResponse;
+        } else {
+            content['assistant_response'] = toStr(assistantResponse);
+        }
+    } else {
+        content['assistant_response'] = '';
+    }
+    return content;
+}
+
+export class AssistantResponse extends RoledMessage {
+    constructor(
+        assistantResponse: BaseModel | JsonValue | MessageFlag,
+        sender: ID.Ref | MessageFlag,
+        recipient: ID.Ref | MessageFlag,
+        protectedInitParams: Record<string, any> = null
+    ) {
+        const messageFlags = [assistantResponse, sender, recipient];
+
+        if (messageFlags.every(flag => flag === MessageFlag.MESSAGE_LOAD)) {
+            protectedInitParams = protectedInitParams || {};
+            super(protectedInitParams);
+            return;
+        }
+
+        if (messageFlags.every(flag => flag === MessageFlag.MESSAGE_CLONE)) {
+            super({ role: MessageRole.ASSISTANT });
+            return;
+        }
+
+        super({
+            role: MessageRole.ASSISTANT,
+            sender: sender || 'N/A',
+            recipient: recipient
+        });
+
+        const content = prepareAssistantResponse(assistantResponse);
+        if ('model_response' in content) {
+            this.metadata['model_response'] = content['model_response'];
+            delete content['model_response'];
+        }
+        this.content = content;
+    }
+
+    get response(): string {
+        return copy(this.content['assistant_response']);
+    }
+
+    get modelResponse(): Record<string, any> | Record<string, any>[] {
+        return copy(this.metadata['model_response'] || {});
+    }
+
+    protected _formatContent(): Record<string, any> {
+        return {
+            role: this.role.value,
+            content: this.response
+        };
+    }
+}

--- a/src/core/communication/instruction.ts
+++ b/src/core/communication/instruction.ts
@@ -1,0 +1,239 @@
+import { ID, Any, BaseModel, JsonValue, Literal } from '../../core/typing';
+import { breakDownPydanticAnnotation } from '../../integrations/pydantic_';
+import { toStr } from '../../libs/parse';
+import { copy } from '../../libs/utils';
+import { MessageFlag, MessageRole, RoledMessage } from './message';
+import { formatImageContent, formatTextContent, prepareInstructionContent, prepareRequestResponseFormat } from './utils';
+
+export class Instruction extends RoledMessage {
+    constructor(
+        instruction: JsonValue | MessageFlag,
+        context: JsonValue | MessageFlag = null,
+        guidance: JsonValue | MessageFlag = null,
+        images: any[] | MessageFlag = null,
+        sender: ID.Ref | MessageFlag = null,
+        recipient: ID.Ref | MessageFlag = null,
+        requestFields: JsonValue | MessageFlag = null,
+        plainContent: JsonValue | MessageFlag = null,
+        imageDetail: Literal<'low' | 'high' | 'auto'> | MessageFlag = null,
+        requestModel: BaseModel | typeof BaseModel | MessageFlag = null,
+        toolSchemas: Record<string, any> = null,
+        protectedInitParams: Record<string, any> = null
+    ) {
+        const messageFlags = [
+            instruction,
+            context,
+            guidance,
+            images,
+            sender,
+            recipient,
+            requestFields,
+            plainContent,
+            imageDetail,
+            toolSchemas,
+            requestModel
+        ];
+
+        if (messageFlags.every(flag => flag === MessageFlag.MESSAGE_LOAD)) {
+            protectedInitParams = protectedInitParams || {};
+            super(protectedInitParams);
+            return;
+        }
+
+        if (messageFlags.every(flag => flag === MessageFlag.MESSAGE_CLONE)) {
+            super({ role: MessageRole.USER });
+            return;
+        }
+
+        super({
+            role: MessageRole.USER,
+            content: prepareInstructionContent({
+                guidance,
+                instruction,
+                context,
+                images,
+                requestFields,
+                plainContent,
+                imageDetail,
+                requestModel,
+                toolSchemas
+            }),
+            sender: sender || 'user',
+            recipient: recipient || 'N/A'
+        });
+    }
+
+    get guidance(): string | null {
+        return this.content.get('guidance', null);
+    }
+
+    set guidance(guidance: string) {
+        if (typeof guidance !== 'string') {
+            guidance = toStr(guidance);
+        }
+        this.content['guidance'] = guidance;
+    }
+
+    get instruction(): JsonValue | null {
+        if ('plain_content' in this.content) {
+            return this.content['plain_content'];
+        } else {
+            return this.content.get('instruction', null);
+        }
+    }
+
+    set instruction(instruction: JsonValue) {
+        this.content['instruction'] = instruction;
+    }
+
+    get context(): JsonValue | null {
+        return this.content.get('context', null);
+    }
+
+    set context(context: JsonValue) {
+        if (!Array.isArray(context)) {
+            context = [context];
+        }
+        this.content['context'] = context;
+    }
+
+    get toolSchemas(): JsonValue | null {
+        return this.content.get('tool_schemas', null);
+    }
+
+    set toolSchemas(toolSchemas: Record<string, any>) {
+        this.content['tool_schemas'] = toolSchemas;
+    }
+
+    get plainContent(): string | null {
+        return this.content.get('plain_content', null);
+    }
+
+    set plainContent(plainContent: string) {
+        this.content['plain_content'] = plainContent;
+    }
+
+    get imageDetail(): Literal<'low' | 'high' | 'auto'> | null {
+        return this.content.get('image_detail', null);
+    }
+
+    set imageDetail(imageDetail: Literal<'low' | 'high' | 'auto'>) {
+        this.content['image_detail'] = imageDetail;
+    }
+
+    get images(): any[] {
+        return this.content.get('images', []);
+    }
+
+    set images(images: any[]) {
+        if (!Array.isArray(images)) {
+            images = [images];
+        }
+        this.content['images'] = images;
+    }
+
+    get requestFields(): Record<string, any> | null {
+        return this.content.get('request_fields', null);
+    }
+
+    set requestFields(requestFields: Record<string, any>) {
+        this.content['request_fields'] = requestFields;
+        this.content['request_response_format'] = prepareRequestResponseFormat(requestFields);
+    }
+
+    get requestModel(): typeof BaseModel | null {
+        return this.content.get('request_model', null);
+    }
+
+    set requestModel(requestModel: typeof BaseModel) {
+        if (requestModel instanceof BaseModel) {
+            this.content['request_model'] = requestModel.constructor;
+        } else {
+            this.content['request_model'] = requestModel;
+        }
+
+        this.requestFields = {};
+        this.extendContext({ respond_schema_info: requestModel.modelJsonSchema() });
+        this.requestFields = breakDownPydanticAnnotation(requestModel);
+    }
+
+    extendImages(images: any[] | string, imageDetail: Literal<'low' | 'high' | 'auto'> = null): void {
+        images = Array.isArray(images) ? images : [images];
+        const currentImages = this.content.get('images', []);
+        currentImages.push(...images);
+        this.images = currentImages;
+
+        if (imageDetail) {
+            this.imageDetail = imageDetail;
+        }
+    }
+
+    extendContext(...args: any[]): void {
+        const context = this.content.get('context', []);
+
+        args.forEach(arg => {
+            if (Array.isArray(arg)) {
+                context.push(...arg);
+            } else {
+                context.push(arg);
+            }
+        });
+
+        this.context = context;
+    }
+
+    update(
+        ...args: any[],
+        guidance: JsonValue = null,
+        instruction: JsonValue = null,
+        requestFields: JsonValue = null,
+        plainContent: JsonValue = null,
+        requestModel: BaseModel | typeof BaseModel = null,
+        images: string | any[] = null,
+        imageDetail: Literal<'low' | 'high' | 'auto'> = null,
+        toolSchemas: Record<string, any> = null,
+        ...kwargs: any[]
+    ): void {
+        if (requestModel && requestFields) {
+            throw new Error('You cannot pass both requestModel and requestFields to create_instruction');
+        }
+        if (guidance) {
+            this.guidance = guidance;
+        }
+        if (instruction) {
+            this.instruction = instruction;
+        }
+        if (plainContent) {
+            this.plainContent = plainContent;
+        }
+        if (requestFields) {
+            this.requestFields = requestFields;
+        }
+        if (requestModel) {
+            this.requestModel = requestModel;
+        }
+        if (images) {
+            this.images = images;
+        }
+        if (imageDetail) {
+            this.imageDetail = imageDetail;
+        }
+        if (toolSchemas) {
+            this.toolSchemas = toolSchemas;
+        }
+        this.extendContext(...args, ...kwargs);
+    }
+
+    protected _formatContent(): Record<string, any> {
+        const content = this.content.toDict();
+        const textContent = formatTextContent(content);
+        if (!('images' in content)) {
+            return { role: this.role.value, content: textContent };
+        } else {
+            return {
+                role: this.role.value,
+                content: formatImageContent(textContent, this.images, this.imageDetail)
+            };
+        }
+    }
+}

--- a/src/core/communication/message.ts
+++ b/src/core/communication/message.ts
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2024 HaiyangLi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fieldSerializer, fieldValidator } from 'pydantic';
+import { Component, Log } from '../../core/generic';
+import { Any, Communicatable, Enum, Field, Note, override } from '../../core/typing';
+import { copy } from '../../libs/utils';
+import { getClass } from '../_class_registry';
+import { BaseMail } from './base_mail';
+
+export enum MessageRole {
+    SYSTEM = 'system',
+    USER = 'user',
+    ASSISTANT = 'assistant'
+}
+
+export enum MessageFlag {
+    MESSAGE_CLONE = 'MESSAGE_CLONE',
+    MESSAGE_LOAD = 'MESSAGE_LOAD'
+}
+
+export enum MessageField {
+    TIMESTAMP = 'timestamp',
+    LION_CLASS = 'lion_class',
+    ROLE = 'role',
+    CONTENT = 'content',
+    LN_ID = 'ln_id',
+    SENDER = 'sender',
+    RECIPIENT = 'recipient',
+    METADATA = 'metadata'
+}
+
+const MESSAGE_FIELDS = Object.values(MessageField);
+
+export class RoledMessage extends Component(BaseMail) {
+    content: Note = Field({
+        defaultFactory: () => new Note(),
+        description: 'The content of the message.'
+    });
+
+    role: MessageRole | null = Field({
+        default: null,
+        description: 'The role of the message in the conversation.',
+        examples: ['system', 'user', 'assistant']
+    });
+
+    get imageContent(): Array<Record<string, Any>> | null {
+        const msg = this.chatMsg;
+        if (typeof msg === 'object' && Array.isArray(msg.content)) {
+            return msg.content.filter((i: any) => i.type === 'image_url');
+        }
+        return null;
+    }
+
+    get chatMsg(): Record<string, Any> | null {
+        try {
+            return this._formatContent();
+        } catch (error) {
+            return null;
+        }
+    }
+
+    @fieldValidator('role')
+    static _validateRole(value: Any): MessageRole | null {
+        if (Object.values(MessageRole).includes(value)) {
+            return value as MessageRole;
+        }
+        throw new Error(`Invalid message role: ${value}`);
+    }
+
+    clone(): RoledMessage {
+        const cls = this.constructor as typeof RoledMessage;
+        const signature = Reflect.getMetadata('design:paramtypes', cls.prototype, 'constructor');
+        const paramNum = signature.length - 2;
+
+        const initArgs = Array(paramNum).fill(MessageFlag.MESSAGE_CLONE);
+
+        const obj = new cls(...initArgs);
+        obj.role = this.role;
+        obj.content = this.content;
+        obj.metadata.set('clone_from', this);
+
+        return obj;
+    }
+
+    @override
+    static fromDict(data: Record<string, any>, ...kwargs: any[]): RoledMessage {
+        data = copy(data);
+        if (kwargs.length) {
+            Object.assign(data, ...kwargs);
+        }
+        if ('lion_class' in data) {
+            const cls = getClass(data.lion_class);
+            delete data.lion_class;
+            return cls.fromDict(data, ...kwargs);
+        }
+        const cls = this;
+        const signature = Reflect.getMetadata('design:paramtypes', cls.prototype, 'constructor');
+        const paramNum = signature.length - 2;
+
+        const initArgs = Array(paramNum).fill(MessageFlag.MESSAGE_LOAD);
+
+        const extraFields: Record<string, any> = {};
+        for (const [k, v] of Object.entries(data)) {
+            if (!(k in cls.prototype)) {
+                extraFields[k] = v;
+                delete data[k];
+            }
+        }
+
+        const obj = new cls(...initArgs, { protectedInitParams: data });
+
+        for (const [k, v] of Object.entries(extraFields)) {
+            obj.addField(k, v);
+        }
+
+        const metadata = data.metadata || {};
+        const lastUpdated = metadata.last_updated || null;
+        if (lastUpdated !== null) {
+            obj.metadata.set('last_updated', lastUpdated);
+        }
+        return obj;
+    }
+
+    @override
+    toString(): string {
+        const contentPreview = this.content.toString().slice(0, 75);
+        const contentStr = contentPreview.length === 75 ? `${contentPreview}...` : contentPreview;
+        return `Message(role=${this.role}, sender=${this.sender}, content='${contentStr}')`;
+    }
+
+    toLog(): Log {
+        const dict = this.toDict();
+        const content = dict.content;
+        delete dict.content;
+        return new Log({
+            content: content,
+            loginfo: dict
+        });
+    }
+
+    @fieldSerializer('content')
+    _serializeContent(value: Note): Record<string, Any> {
+        const outputDict = copy(value.content, true);
+        const originObj = outputDict.clone_from;
+
+        if (originObj && originObj instanceof Communicatable) {
+            const infoDict = {
+                clone_from_info: {
+                    original_ln_id: originObj.ln_id,
+                    original_timestamp: originObj.timestamp,
+                    original_sender: originObj.sender,
+                    original_recipient: originObj.recipient
+                }
+            };
+            Object.assign(outputDict, infoDict);
+        }
+        return outputDict;
+    }
+
+    @fieldSerializer('role')
+    _serializeRole(value: MessageRole): string {
+        return value.value;
+    }
+
+    protected _formatContent(): Record<string, Any> {
+        const content = this.content.get('images', null) ? this.content.toDict() : this.content.toString();
+        return {
+            role: this.role.value,
+            content: content
+        };
+    }
+}

--- a/src/core/communication/message_manager.ts
+++ b/src/core/communication/message_manager.ts
@@ -1,0 +1,402 @@
+import { LogManager, Pile, Progression } from '../../core/generic';
+import { ID, Any, BaseModel, JsonValue, Literal } from '../../core/typing';
+import { ActionRequest } from './action_request';
+import { ActionResponse } from './action_response';
+import { AssistantResponse } from './assistant_response';
+import { Instruction } from './instruction';
+import { RoledMessage } from './message';
+import { System } from './system';
+
+const DEFAULT_SYSTEM = "You are a helpful AI assistant. Let's think step by step.";
+
+export class MessageManager {
+    messages: Pile<RoledMessage>;
+    logger: LogManager;
+    system: System | null;
+    saveOnClear: boolean;
+
+    constructor(messages: RoledMessage[] = [], logger: LogManager = new LogManager(), system: System | null = null, saveOnClear: boolean = true) {
+        this.messages = new Pile(messages, { itemType: RoledMessage });
+        this.logger = logger;
+        this.system = system;
+        this.saveOnClear = saveOnClear;
+        if (this.system) {
+            this.addMessage({ system: this.system });
+        }
+    }
+
+    setSystem(system: System): void {
+        if (!this.system) {
+            this.system = system;
+            this.messages.insert(0, this.system);
+        } else {
+            const oldSystem = this.system;
+            this.system = system;
+            this.messages.insert(0, this.system);
+            this.messages.exclude(oldSystem);
+        }
+    }
+
+    async aclearMessages(): Promise<void> {
+        await this.messages.lock(async () => {
+            this.clearMessages();
+        });
+    }
+
+    async aAddMessage(kwargs: Record<string, any>): Promise<RoledMessage> {
+        return await this.messages.lock(async () => {
+            return this.addMessage(kwargs);
+        });
+    }
+
+    get progress(): Progression {
+        return new Progression({ order: this.messages.items });
+    }
+
+    static createInstruction({
+        sender = null,
+        recipient = null,
+        instruction = null,
+        context = null,
+        guidance = null,
+        plainContent = null,
+        requestFields = null,
+        requestModel = null,
+        images = null,
+        imageDetail = null,
+        toolSchemas = null,
+        ...kwargs
+    }: {
+        sender?: ID.SenderRecipient | null,
+        recipient?: ID.SenderRecipient | null,
+        instruction?: Instruction | JsonValue | null,
+        context?: JsonValue | null,
+        guidance?: JsonValue | null,
+        plainContent?: string | null,
+        requestFields?: string[] | Record<string, Any> | null,
+        requestModel?: typeof BaseModel | BaseModel | null,
+        images?: any[] | null,
+        imageDetail?: Literal<'low' | 'high' | 'auto'> | null,
+        toolSchemas?: Record<string, any> | null,
+        [key: string]: any
+    } = {}): Instruction {
+        if (instruction instanceof Instruction) {
+            instruction.update(
+                context,
+                { guidance, requestFields, plainContent, requestModel, images, imageDetail, toolSchemas, ...kwargs }
+            );
+            if (sender) {
+                instruction.sender = sender;
+            }
+            if (recipient) {
+                instruction.recipient = recipient;
+            }
+            return instruction;
+        } else {
+            return new Instruction(
+                instruction,
+                context,
+                guidance,
+                images,
+                sender,
+                recipient,
+                requestFields,
+                plainContent,
+                imageDetail,
+                requestModel,
+                toolSchemas,
+                kwargs
+            );
+        }
+    }
+
+    static createAssistantResponse({
+        sender = null,
+        recipient = null,
+        assistantResponse = null
+    }: {
+        sender?: Any | null,
+        recipient?: Any | null,
+        assistantResponse?: AssistantResponse | Any | null
+    } = {}): AssistantResponse {
+        if (assistantResponse instanceof AssistantResponse) {
+            if (sender) {
+                assistantResponse.sender = sender;
+            }
+            if (recipient) {
+                assistantResponse.recipient = recipient;
+            }
+            return assistantResponse;
+        }
+
+        return new AssistantResponse(
+            assistantResponse,
+            sender,
+            recipient
+        );
+    }
+
+    static createActionRequest({
+        sender = null,
+        recipient = null,
+        function: functionName = null,
+        arguments: args = null,
+        actionRequest = null
+    }: {
+        sender?: ID.SenderRecipient | null,
+        recipient?: ID.SenderRecipient | null,
+        function?: string | null,
+        arguments?: Record<string, Any> | null,
+        actionRequest?: ActionRequest | null
+    } = {}): ActionRequest {
+        if (actionRequest) {
+            if (!(actionRequest instanceof ActionRequest)) {
+                throw new Error("Error: action request must be an instance of ActionRequest.");
+            }
+            if (sender) {
+                actionRequest.sender = sender;
+            }
+            if (recipient) {
+                actionRequest.recipient = recipient;
+            }
+            return actionRequest;
+        }
+
+        return new ActionRequest(
+            functionName,
+            args,
+            sender,
+            recipient
+        );
+    }
+
+    static createActionResponse({
+        actionRequest,
+        actionResponse = null
+    }: {
+        actionRequest: ActionRequest,
+        actionResponse?: ActionResponse | Any | null
+    }): ActionResponse {
+        if (!(actionRequest instanceof ActionRequest)) {
+            throw new Error("Error: please provide a corresponding action request for an action response.");
+        }
+
+        if (actionResponse) {
+            if (actionResponse instanceof ActionResponse) {
+                if (actionRequest.isResponded) {
+                    throw new Error("Error: action request already has a response.");
+                }
+                actionRequest.content.action_response_id = actionResponse.ln_id;
+                return actionResponse;
+            }
+        }
+
+        return new ActionResponse(
+            actionRequest,
+            actionResponse
+        );
+    }
+
+    static createSystem({
+        system = null,
+        sender = null,
+        recipient = null,
+        systemDatetime = null
+    }: {
+        system?: Any | null,
+        sender?: Any | null,
+        recipient?: Any | null,
+        systemDatetime?: boolean | string | null
+    } = {}): System {
+        system = system || DEFAULT_SYSTEM;
+
+        if (system instanceof System) {
+            system.update({
+                sender,
+                recipient,
+                systemDatetime
+            });
+            return system;
+        }
+
+        return new System(
+            system,
+            sender,
+            recipient,
+            systemDatetime
+        );
+    }
+
+    addMessage({
+        sender = null,
+        recipient = null,
+        instruction = null,
+        context = null,
+        guidance = null,
+        plainContent = null,
+        requestFields = null,
+        requestModel = null,
+        images = null,
+        imageDetail = null,
+        assistantResponse = null,
+        system = null,
+        systemDatetime = null,
+        function: functionName = null,
+        arguments: args = null,
+        actionRequest = null,
+        actionResponse = null,
+        metadata = null
+    }: {
+        sender?: ID.SenderRecipient | null,
+        recipient?: ID.SenderRecipient | null,
+        instruction?: Instruction | JsonValue | null,
+        context?: JsonValue | null,
+        guidance?: JsonValue | null,
+        plainContent?: string | null,
+        requestFields?: string[] | Record<string, Any> | null,
+        requestModel?: typeof BaseModel | BaseModel | null,
+        images?: any[] | null,
+        imageDetail?: Literal<'low' | 'high' | 'auto'> | null,
+        assistantResponse?: AssistantResponse | Any | null,
+        system?: System | Any | null,
+        systemDatetime?: boolean | string | null,
+        function?: string | null,
+        arguments?: Record<string, Any> | null,
+        actionRequest?: ActionRequest | null,
+        actionResponse?: ActionResponse | Any | null,
+        metadata?: Record<string, any> | null
+    } = {}): RoledMessage {
+        let _msg: RoledMessage | null = null;
+        if ([instruction, assistantResponse, system].filter(Boolean).length > 1) {
+            throw new Error("Only one message type can be added at a time.");
+        }
+
+        if (system) {
+            _msg = MessageManager.createSystem({
+                system,
+                sender,
+                recipient,
+                systemDatetime
+            });
+            this.setSystem(_msg as System);
+        } else if (actionResponse) {
+            if (!actionRequest) {
+                throw new Error("Error: Action response must have an action request.");
+            }
+            _msg = MessageManager.createActionResponse({
+                actionRequest,
+                actionResponse
+            });
+        } else if (actionRequest || (functionName && args)) {
+            _msg = MessageManager.createActionRequest({
+                sender,
+                recipient,
+                function: functionName,
+                arguments: args,
+                actionRequest
+            });
+        } else if (assistantResponse) {
+            _msg = MessageManager.createAssistantResponse({
+                sender,
+                recipient,
+                assistantResponse
+            });
+        } else {
+            _msg = MessageManager.createInstruction({
+                sender,
+                recipient,
+                instruction,
+                context,
+                guidance,
+                plainContent,
+                requestFields,
+                requestModel,
+                images,
+                imageDetail
+            });
+        }
+
+        if (metadata) {
+            _msg.metadata.update('extra', metadata);
+        }
+
+        if (this.messages.includes(_msg)) {
+            this.messages.update(_msg);
+        } else {
+            this.messages.include(_msg);
+        }
+
+        this.logger.log(_msg.toLog());
+        return _msg;
+    }
+
+    clearMessages(): void {
+        if (this.saveOnClear) {
+            this.logger.dump({ clear: true });
+        }
+
+        this.messages.clear();
+        this.progress.clear();
+        if (this.system) {
+            this.messages.include(this.system);
+            this.progress.insert(0, this.system);
+        }
+    }
+
+    get lastResponse(): AssistantResponse | null {
+        for (let i = this.messages.items.length - 1; i >= 0; i--) {
+            if (this.messages.items[i] instanceof AssistantResponse) {
+                return this.messages.items[i] as AssistantResponse;
+            }
+        }
+        return null;
+    }
+
+    get lastInstruction(): Instruction | null {
+        for (let i = this.messages.items.length - 1; i >= 0; i--) {
+            if (this.messages.items[i] instanceof Instruction) {
+                return this.messages.items[i] as Instruction;
+            }
+        }
+        return null;
+    }
+
+    get assistantResponses(): Pile<AssistantResponse> {
+        return new Pile(
+            this.messages.items.filter(item => item instanceof AssistantResponse) as AssistantResponse[]
+        );
+    }
+
+    get actionRequests(): Pile<ActionRequest> {
+        return new Pile(
+            this.messages.items.filter(item => item instanceof ActionRequest) as ActionRequest[]
+        );
+    }
+
+    get actionResponses(): Pile<ActionResponse> {
+        return new Pile(
+            this.messages.items.filter(item => item instanceof ActionResponse) as ActionResponse[]
+        );
+    }
+
+    get instructions(): Pile<Instruction> {
+        return new Pile(
+            this.messages.items.filter(item => item instanceof Instruction) as Instruction[]
+        );
+    }
+
+    toChatMsgs(progress: number[] = []): Record<string, any>[] {
+        if (progress.length === 0) {
+            return [];
+        }
+        try {
+            return progress.map(i => this.messages.items[i].chatMsg);
+        } catch (error) {
+            throw new Error("Invalid progress, not all requested messages are in the message pile");
+        }
+    }
+
+    get hasLogs(): boolean {
+        return !this.logger.logs.isEmpty();
+    }
+}

--- a/src/core/communication/system.ts
+++ b/src/core/communication/system.ts
@@ -1,0 +1,64 @@
+import { ID, Any, JsonValue } from '../../core/typing';
+import { toStr } from '../../libs/parse';
+import { MessageFlag, MessageRole, RoledMessage } from './message';
+import { formatSystemContent, validateSenderRecipient } from './utils';
+
+export class System extends RoledMessage {
+    constructor(
+        system: JsonValue = null,
+        sender: ID.SenderRecipient = null,
+        recipient: ID.SenderRecipient = null,
+        systemDatetime: boolean | JsonValue = null,
+        protectedInitParams: Record<string, any> = null
+    ) {
+        if ([system, sender, recipient, systemDatetime].every(x => x === MessageFlag.MESSAGE_LOAD)) {
+            super(protectedInitParams);
+            return;
+        }
+
+        if ([system, sender, recipient, systemDatetime].every(x => x === MessageFlag.MESSAGE_CLONE)) {
+            super({ role: MessageRole.SYSTEM });
+            return;
+        }
+
+        super({
+            role: MessageRole.SYSTEM,
+            sender: sender || 'system',
+            content: formatSystemContent(systemDatetime, system),
+            recipient: recipient || 'N/A'
+        });
+    }
+
+    update(
+        system: JsonValue = null,
+        sender: ID.SenderRecipient = null,
+        recipient: ID.Ref = null,
+        systemDatetime: boolean | string = null
+    ): void {
+        if (system) {
+            this.content = formatSystemContent(systemDatetime, system);
+        }
+        if (sender) {
+            this.sender = validateSenderRecipient(sender);
+        }
+        if (recipient) {
+            this.recipient = validateSenderRecipient(recipient);
+        }
+    }
+
+    get systemInfo(): string {
+        if ('system_datetime' in this.content) {
+            const msg = `System datetime: ${this.content['system_datetime']}\n\n`;
+            return msg + `${this.content['system']}`;
+        }
+
+        return toStr(this.content['system']);
+    }
+
+    protected _formatContent(): Record<string, any> {
+        return {
+            role: this.role.value,
+            content: this.systemInfo
+        };
+    }
+}

--- a/src/core/communication/utils.ts
+++ b/src/core/communication/utils.ts
@@ -1,0 +1,142 @@
+import { ID, UNDEFINED, Any, BaseModel, IDError, Literal, LnID, Note } from '../../core/typing';
+import { breakDownPydanticAnnotation } from '../../integrations/pydantic_/break_down_annotation';
+import { time } from '../../libs/utils';
+
+const DEFAULT_SYSTEM = "You are a helpful AI assistant. Let's think step by step.";
+
+export function formatSystemContent(systemDatetime: boolean | string | null, systemMessage: string): Note {
+    const content = new Note({ system: systemMessage || DEFAULT_SYSTEM });
+    if (systemDatetime) {
+        if (typeof systemDatetime === 'string') {
+            content['system_datetime'] = systemDatetime;
+        } else {
+            content['system_datetime'] = time({ type: 'iso', timespec: 'minutes' });
+        }
+    }
+    return content;
+}
+
+export function prepareRequestResponseFormat(requestFields: Record<string, any>): string {
+    return `**MUST RETURN JSON-PARSEABLE RESPONSE ENCLOSED BY JSON CODE BLOCKS.** \n\`\`\`json\n${JSON.stringify(requestFields, null, 2)}\n\`\`\``.trim();
+}
+
+export function formatImageItem(idx: string, x: string): Record<string, any> {
+    return {
+        type: 'image_url',
+        image_url: {
+            url: `data:image/jpeg;base64,${idx}`,
+            detail: x
+        }
+    };
+}
+
+export function formatTextItem(item: any): string {
+    let msg = '';
+    const items = Array.isArray(item) ? item : [item];
+    for (const j of items) {
+        if (typeof j === 'object') {
+            for (const [k, v] of Object.entries(j)) {
+                msg += `- ${k}: ${v} \n\n`;
+            }
+        } else {
+            msg += `${j}\n`;
+        }
+    }
+    return msg;
+}
+
+export function formatTextContent(content: Record<string, any>): string {
+    if ('plain_content' in content && typeof content['plain_content'] === 'string') {
+        return content['plain_content'];
+    }
+
+    let msg = "\n---\n # Task\n";
+    for (const [k, v] of Object.entries(content)) {
+        if (['guidance', 'instruction', 'context', 'request_response_format', 'tool_schemas'].includes(k)) {
+            const key = k === 'request_response_format' ? 'response format' : k;
+            msg += `## **Task ${key}**\n${formatTextItem(v)}\n\n`;
+        }
+    }
+    msg += "\n\n---\n";
+    return msg;
+}
+
+export function formatImageContent(textContent: string, images: string[], imageDetail: Literal<'low' | 'high' | 'auto'>): Record<string, any>[] {
+    const content = [{ type: 'text', text: textContent }];
+    content.push(...images.map(idx => formatImageItem(idx, imageDetail)));
+    return content;
+}
+
+export function prepareInstructionContent({
+    guidance = null,
+    instruction = null,
+    context = null,
+    requestFields = null,
+    plainContent = null,
+    requestModel = null,
+    images = null,
+    imageDetail = null,
+    toolSchemas = null
+}: {
+    guidance?: string | null,
+    instruction?: string | null,
+    context?: string | Record<string, any> | any[] | null,
+    requestFields?: Record<string, any> | string[] | null,
+    plainContent?: string | null,
+    requestModel?: typeof BaseModel | null,
+    images?: string | string[] | null,
+    imageDetail?: Literal<'low' | 'high' | 'auto'> | null,
+    toolSchemas?: Record<string, any> | null
+} = {}): Note {
+    if (requestFields && requestModel) {
+        throw new Error("only one of requestFields or requestModel can be provided");
+    }
+
+    const out: Record<string, any> = { context: [] };
+    if (guidance) out['guidance'] = guidance;
+    if (instruction) out['instruction'] = instruction;
+    if (context) {
+        if (Array.isArray(context)) {
+            out['context'].push(...context);
+        } else {
+            out['context'].push(context);
+        }
+    }
+    if (images) {
+        out['images'] = Array.isArray(images) ? images : [images];
+        out['image_detail'] = imageDetail || 'low';
+    }
+    if (toolSchemas) out['tool_schemas'] = toolSchemas;
+    if (requestModel) {
+        out['request_model'] = requestModel;
+        requestFields = breakDownPydanticAnnotation(requestModel);
+        out['context'].push({ respond_schema_info: requestModel.modelJsonSchema() });
+    }
+    if (requestFields) {
+        const fields = Array.isArray(requestFields) ? Object.fromEntries(requestFields.map(i => [i, '...'])) : requestFields;
+        out['request_fields'] = fields;
+        out['request_response_format'] = prepareRequestResponseFormat(fields);
+    }
+    if (plainContent) out['plain_content'] = plainContent;
+
+    return new Note(out);
+}
+
+export function validateSenderRecipient(value: any): LnID | Literal<'system' | 'user' | 'N/A' | 'assistant'> {
+    if (['system', 'user', 'N/A', 'assistant'].includes(value)) {
+        return value;
+    }
+
+    if (value === null) {
+        return 'N/A';
+    }
+
+    try {
+        return ID.getId(value);
+    } catch (error) {
+        if (error instanceof IDError) {
+            throw new Error("Invalid sender or recipient");
+        }
+        throw error;
+    }
+}

--- a/src/core/forms/base.ts
+++ b/src/core/forms/base.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod';
+
+interface BaseFormProps {
+  assignment?: string;
+  templateName?: string;
+  outputFields?: string[];
+  noneAsValidValue?: boolean;
+  hasProcessed?: boolean;
+}
+
+export class BaseForm {
+  assignment: string | undefined;
+  templateName: string;
+  outputFields: string[];
+  noneAsValidValue: boolean;
+  hasProcessed: boolean;
+
+  constructor({
+    assignment,
+    templateName = 'default_form',
+    outputFields = [],
+    noneAsValidValue = false,
+    hasProcessed = false,
+  }: BaseFormProps) {
+    this.assignment = assignment;
+    this.templateName = templateName;
+    this.outputFields = outputFields;
+    this.noneAsValidValue = noneAsValidValue;
+    this.hasProcessed = hasProcessed;
+  }
+
+  checkIsCompleted(
+    handleHow: 'raise' | 'return_missing' = 'raise'
+  ): string[] | undefined {
+    const nonCompleteRequest: string[] = [];
+    const invalidValues = [undefined, null];
+
+    for (const field of this.requiredFields) {
+      if (invalidValues.includes((this as any)[field])) {
+        nonCompleteRequest.push(field);
+      }
+    }
+
+    if (nonCompleteRequest.length > 0) {
+      if (handleHow === 'raise') {
+        throw new Error(`Incomplete request fields: ${nonCompleteRequest}`);
+      } else if (handleHow === 'return_missing') {
+        return nonCompleteRequest;
+      }
+    } else {
+      this.hasProcessed = true;
+    }
+  }
+
+  isCompleted(): boolean {
+    try {
+      this.checkIsCompleted('raise');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  static validateOutput(value: any): string[] {
+    if (typeof value === 'string') {
+      return [value];
+    }
+    if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
+      return value;
+    }
+    if (!value) {
+      return [];
+    }
+    throw new Error('Invalid output fields.');
+  }
+
+  get workFields(): string[] {
+    return this.outputFields;
+  }
+
+  get workDict(): Record<string, any> {
+    const result: Record<string, any> = {};
+    for (const field of this.workFields) {
+      result[field] = (this as any)[field];
+    }
+    return result;
+  }
+
+  get requiredFields(): string[] {
+    return this.outputFields;
+  }
+
+  get requiredDict(): Record<string, any> {
+    const result: Record<string, any> = {};
+    for (const field of this.requiredFields) {
+      result[field] = (this as any)[field];
+    }
+    return result;
+  }
+
+  getResults(suppress = false, validOnly = false): Record<string, any> {
+    const result: Record<string, any> = {};
+    const outFields = this.outputFields || (this as any).requestFields || [];
+
+    for (const field of outFields) {
+      if (!(field in this)) {
+        if (!suppress) {
+          throw new Error(`Missing field: ${field}`);
+        }
+      } else {
+        result[field] = (this as any)[field];
+      }
+    }
+
+    if (validOnly) {
+      const invalidValues = [undefined, null];
+      const validResult: Record<string, any> = {};
+      for (const [key, value] of Object.entries(result)) {
+        if (!invalidValues.includes(value)) {
+          validResult[key] = value;
+        }
+      }
+      return validResult;
+    }
+
+    return result;
+  }
+
+  get displayDict(): Record<string, any> {
+    return this.requiredDict;
+  }
+}

--- a/src/core/forms/form.ts
+++ b/src/core/forms/form.ts
@@ -1,0 +1,374 @@
+import { z } from 'zod';
+import { BaseForm } from './base';
+import { getInputOutputFields } from './utils';
+
+const UNDEFINED = Symbol('UNDEFINED');
+
+interface FormProps {
+  assignment: string;
+  strictForm?: boolean;
+  guidance?: string | Record<string, any>;
+  inputFields?: string[];
+  requestFields?: string[];
+  task?: any;
+  taskDescription?: string;
+  initInputKwargs?: Record<string, any>;
+  noneAsValidValue?: boolean;
+  outputFields?: string[];
+}
+
+export class Form extends BaseForm {
+  strictForm: boolean;
+  guidance: string | Record<string, any> | undefined;
+  inputFields: string[];
+  requestFields: string[];
+  task: any;
+  taskDescription: string | undefined;
+  initInputKwargs: Record<string, any>;
+
+  constructor({
+    assignment,
+    strictForm = false,
+    guidance,
+    inputFields = [],
+    requestFields = [],
+    task = '',
+    taskDescription,
+    initInputKwargs = {},
+    noneAsValidValue = false,
+    outputFields = [],
+  }: FormProps) {
+    super({ assignment, templateName: 'default_form', outputFields, noneAsValidValue });
+    this.strictForm = strictForm;
+    this.guidance = guidance;
+    this.inputFields = inputFields;
+    this.requestFields = requestFields;
+    this.task = task;
+    this.taskDescription = taskDescription;
+    this.initInputKwargs = initInputKwargs;
+
+    const fields = getInputOutputFields(assignment);
+    this.inputFields = fields.inputFields;
+    this.requestFields = fields.requestFields;
+    this.outputFields = outputFields.length ? outputFields : fields.requestFields;
+
+    for (const field of this.inputFields) {
+      this.initInputKwargs[field] = this.initInputKwargs[field] ?? UNDEFINED;
+    }
+  }
+
+  checkIsCompleted(handleHow: 'return_missing' | 'raise' = 'raise'): string[] | undefined {
+    if (this.strictForm && this.hasProcessed) {
+      return;
+    }
+    return super.checkIsCompleted(handleHow);
+  }
+
+  static checkInputOutputListOmitted(data: any): any {
+    if (typeof data !== 'object' || data === null) {
+      throw new TypeError('Input data must be a dictionary.');
+    }
+
+    if (!data.assignment) {
+      throw new Error('Assignment is missing.');
+    }
+
+    if ('inputFields' in data || 'requestFields' in data || 'task' in data) {
+      throw new Error('Explicit inputFields, requestFields, or task fields are not allowed.');
+    }
+
+    const fields = getInputOutputFields(data.assignment);
+    data.inputFields = fields.inputFields;
+    data.requestFields = fields.requestFields;
+    data.outputFields = data.outputFields || fields.requestFields;
+    data.initInputKwargs = {};
+
+    for (const field of data.inputFields) {
+      data.initInputKwargs[field] = data[field] ?? UNDEFINED;
+    }
+
+    return data;
+  }
+
+  static checkInputOutputFields(data: any): Form {
+    const form = new Form(data);
+    for (const field of form.inputFields) {
+      form.initInputKwargs[field] = form[field];
+    }
+    for (const field of form.requestFields) {
+      if (!(field in form)) {
+        form[field] = UNDEFINED;
+      }
+    }
+    return form;
+  }
+
+  get workFields(): string[] {
+    return [...this.inputFields, ...this.requestFields];
+  }
+
+  get requiredFields(): string[] {
+    return Array.from(new Set([...this.inputFields, ...this.requestFields, ...this.outputFields]));
+  }
+
+  get validationKwargs(): Record<string, any> {
+    const result: Record<string, any> = {};
+    for (const field of this.workFields) {
+      result[field] = (this as any)[field]?.validationKwargs || {};
+    }
+    return result;
+  }
+
+  get instructionDict(): Record<string, any> {
+    return {
+      context: this.instructionContext,
+      instruction: this.instructionPrompt,
+      requestFields: this.instructionRequestFields,
+    };
+  }
+
+  get instructionContext(): string {
+    let context = '### Input Fields:\n';
+    for (const [idx, field] of this.inputFields.entries()) {
+      context += `Input No.${idx + 1}: ${field}\n`;
+      context += `  - value: ${(this as any)[field]}\n`;
+    }
+    return context;
+  }
+
+  get instructionPrompt(): string {
+    let prompt = '';
+    if (this.guidance) {
+      prompt += `### Overall Guidance:\n${this.guidance}.\n`;
+    }
+
+    const inFields = this.inputFields.join(', ');
+    const outFields = this.outputFields.join(', ');
+    prompt += '### Task Instructions:\n';
+    prompt += `1. Provided Input Fields: ${inFields}.\n`;
+    prompt += `2. Requested Output Fields: ${outFields}.\n`;
+    prompt += `3. Your task:\n${this.task}.\n`;
+
+    return prompt;
+  }
+
+  get instructionRequestFields(): string {
+    let context = '### Output Fields:\n';
+    for (const [idx, field] of this.requestFields.entries()) {
+      context += `Input No.${idx + 1}: ${field}\n`;
+    }
+    return context;
+  }
+
+  updateField(fieldName: string, value: any = UNDEFINED, annotation: any = UNDEFINED, fieldObj: any = UNDEFINED, ...kwargs: any[]): void {
+    (this as any)[fieldName] = value;
+    this.initInputKwargs[fieldName] = value;
+  }
+
+  setField(fieldName: string, value: any): void {
+    if (this.strictForm && ['assignment', 'inputFields', 'requestFields'].includes(fieldName)) {
+      throw new Error(`Cannot modify ${fieldName} in strict form mode.`);
+    }
+    (this as any)[fieldName] = value;
+    this.initInputKwargs[fieldName] = value;
+  }
+
+  checkIsWorkable(handleHow: 'raise' | 'return_missing' = 'raise'): string[] | undefined {
+    if (this.strictForm && this.hasProcessed) {
+      throw new Error('Cannot modify processed form in strict mode.');
+    }
+
+    const missingInputs: string[] = [];
+    const invalidValues = [UNDEFINED, null];
+
+    for (const field of this.inputFields) {
+      if (invalidValues.includes((this as any)[field])) {
+        missingInputs.push(field);
+      }
+    }
+
+    if (missingInputs.length > 0) {
+      if (handleHow === 'raise') {
+        throw new Error(`Incomplete input fields: ${missingInputs}`);
+      } else if (handleHow === 'return_missing') {
+        return missingInputs;
+      }
+    }
+  }
+
+  isWorkable(): boolean {
+    try {
+      this.checkIsWorkable('raise');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  toDict(validOnly = false): Record<string, any> {
+    const result: Record<string, any> = { ...this };
+    if (!validOnly) {
+      return result;
+    }
+
+    const disallowValues = [UNDEFINED, null];
+    return Object.fromEntries(Object.entries(result).filter(([_, value]) => !disallowValues.includes(value)));
+  }
+
+  static fromDict(data: Record<string, any>): Form {
+    const inputData = { ...data };
+    inputData.initInputKwargs = {};
+
+    for (const field of inputData.inputFields) {
+      inputData.initInputKwargs[field] = inputData[field] ?? UNDEFINED;
+    }
+
+    return new Form(inputData);
+  }
+
+  fillInputFields(form: BaseForm | any = null, ...valueKwargs: any[]): void {
+    if (form && !(form instanceof BaseForm)) {
+      throw new TypeError('Provided form is not a BaseForm instance.');
+    }
+
+    for (const field of this.inputFields) {
+      if (this.noneAsValidValue) {
+        if ((this as any)[field] !== UNDEFINED) {
+          continue;
+        }
+        const value = valueKwargs[field] ?? (form ? form[field] : UNDEFINED);
+        if (value !== UNDEFINED) {
+          (this as any)[field] = value;
+        }
+      } else {
+        if ((this as any)[field] === UNDEFINED || (this as any)[field] === null) {
+          const value = valueKwargs[field] ?? (form ? form[field] : UNDEFINED);
+          if (value !== UNDEFINED && value !== null) {
+            (this as any)[field] = value;
+          }
+        }
+      }
+    }
+  }
+
+  fillRequestFields(form: BaseForm | any = null, ...valueKwargs: any[]): void {
+    if (form && !(form instanceof BaseForm)) {
+      throw new TypeError('Provided form is not a BaseForm instance.');
+    }
+
+    for (const field of this.requestFields) {
+      if (this.noneAsValidValue) {
+        if ((this as any)[field] !== UNDEFINED) {
+          continue;
+        }
+        const value = valueKwargs[field] ?? (form ? form[field] : UNDEFINED);
+        if (value !== UNDEFINED) {
+          (this as any)[field] = value;
+        }
+      } else {
+        if ((this as any)[field] === UNDEFINED || (this as any)[field] === null) {
+          const value = valueKwargs[field] ?? (form ? form[field] : UNDEFINED);
+          if (value !== UNDEFINED && value !== null) {
+            (this as any)[field] = value;
+          }
+        }
+      }
+    }
+  }
+
+  static fromForm(
+    form: BaseForm | typeof BaseForm,
+    guidance?: string | Record<string, any>,
+    assignment?: string,
+    strictForm = false,
+    taskDescription?: string,
+    fillInputs = true,
+    noneAsValidValue = false,
+    outputFields?: string[],
+    sameFormOutputFields = false,
+    ...inputValueKwargs: any[]
+  ): Form {
+    if (typeof form === 'function') {
+      if (!(form.prototype instanceof BaseForm)) {
+        throw new TypeError('Provided form is not a BaseForm class.');
+      }
+    } else {
+      if (!(form instanceof BaseForm)) {
+        throw new TypeError('Provided form is not a BaseForm instance.');
+      }
+    }
+
+    if (sameFormOutputFields && outputFields) {
+      throw new Error('Cannot provide outputFields and sameFormOutputFields at the same time.');
+    }
+
+    if (!assignment) {
+      assignment = form.assignment;
+    }
+
+    const obj = new Form({
+      guidance: guidance || form.guidance,
+      assignment,
+      taskDescription: taskDescription || form.taskDescription,
+      noneAsValidValue: noneAsValidValue || form.noneAsValidValue,
+      strictForm: strictForm || form.strictForm,
+      outputFields: outputFields || form.outputFields,
+    });
+
+    for (const field of obj.workFields) {
+      if (!(field in form)) {
+        throw new Error(`Invalid assignment field: ${field}`);
+      }
+      obj.updateField(field, form[field]);
+    }
+
+    if (fillInputs) {
+      obj.fillInputFields(form, ...inputValueKwargs);
+    }
+
+    return obj;
+  }
+
+  removeRequestFromOutput(): void {
+    this.outputFields = this.outputFields.filter((field) => !this.requestFields.includes(field));
+  }
+
+  appendToInput(fieldName: string, value: any = UNDEFINED, annotation: any = UNDEFINED, fieldObj: any = UNDEFINED, ...kwargs: any[]): void {
+    this._appendToOne('input', fieldName, value, annotation, fieldObj, ...kwargs);
+  }
+
+  appendToOutput(fieldName: string, value: any = UNDEFINED, annotation: any = UNDEFINED, fieldObj: any = UNDEFINED, ...kwargs: any[]): void {
+    this._appendToOne('output', fieldName, value, annotation, fieldObj, ...kwargs);
+  }
+
+  appendToRequest(fieldName: string, annotation: any = UNDEFINED, fieldObj: any = UNDEFINED, ...kwargs: any[]): void {
+    this._appendToOne('request', fieldName, UNDEFINED, annotation, fieldObj, ...kwargs);
+  }
+
+  private _appendToOne(
+    fieldType: 'input' | 'output' | 'request',
+    fieldName: string,
+    value: any = UNDEFINED,
+    annotation: any = UNDEFINED,
+    fieldObj: any = UNDEFINED,
+    ...kwargs: any[]
+  ): void {
+    if (this.strictForm && ['input', 'request'].includes(fieldType)) {
+      throw new Error(`Cannot modify ${fieldType} fields in strict form mode.`);
+    }
+
+    if (fieldType === 'input' && !this.inputFields.includes(fieldName)) {
+      this.inputFields.push(fieldName);
+      this.assignment = `${fieldName}, ${this.assignment}`;
+    } else if (fieldType === 'request' && !this.requestFields.includes(fieldName)) {
+      this.requestFields.push(fieldName);
+      this.assignment = `${this.assignment}, ${fieldName}`;
+    } else if (fieldType === 'output' && !this.outputFields.includes(fieldName)) {
+      this.outputFields.push(fieldName);
+    }
+
+    if (value !== UNDEFINED || annotation !== UNDEFINED || fieldObj !== UNDEFINED || kwargs.length > 0 || !(fieldName in this)) {
+      this.updateField(fieldName, value, annotation, fieldObj, ...kwargs);
+    }
+  }
+}

--- a/src/core/forms/report.ts
+++ b/src/core/forms/report.ts
@@ -1,0 +1,189 @@
+import { Pile } from 'lion/core/generic/pile';
+import { UNDEFINED, Field } from 'lion/core/typing';
+import { BaseForm } from './base';
+import { Form } from './form';
+
+interface ReportProps {
+  defaultFormTemplate?: typeof Form;
+  strictForm?: boolean;
+  completedTasks?: Pile<Form>;
+  completedTaskAssignments?: Record<string, string>;
+}
+
+export class Report extends BaseForm {
+  defaultFormTemplate: typeof Form;
+  strictForm: boolean;
+  completedTasks: Pile<Form>;
+  completedTaskAssignments: Record<string, string>;
+
+  constructor({
+    defaultFormTemplate = Form,
+    strictForm = false,
+    completedTasks = new Pile<Form>({ itemType: Form }),
+    completedTaskAssignments = {},
+  }: ReportProps) {
+    super({});
+    this.defaultFormTemplate = defaultFormTemplate;
+    this.strictForm = strictForm;
+    this.completedTasks = completedTasks;
+    this.completedTaskAssignments = completedTaskAssignments;
+  }
+
+  get workFields(): string[] {
+    const baseReportFields = Object.keys(this.constructor.prototype);
+    const allFields = Object.keys(this);
+    return allFields.filter((field) => !baseReportFields.includes(field));
+  }
+
+  getIncompleteFields(noneAsValidValue = false): string[] {
+    const baseReportFields = Object.keys(this.constructor.prototype);
+    const result: string[] = [];
+    for (const field of Object.keys(this)) {
+      if (baseReportFields.includes(field)) continue;
+      if (noneAsValidValue) {
+        if ((this as any)[field] === UNDEFINED) {
+          result.push(field);
+        }
+      } else {
+        if ((this as any)[field] === UNDEFINED || (this as any)[field] === null) {
+          result.push(field);
+        }
+      }
+    }
+    return result;
+  }
+
+  parseAssignment(inputFields: string[], requestFields: string[]): string {
+    if (!Array.isArray(inputFields)) {
+      throw new TypeError('The inputFields must be a list of strings.');
+    }
+
+    if (!Array.isArray(requestFields)) {
+      throw new TypeError('The requestFields must be a list of strings.');
+    }
+
+    for (const field of [...inputFields, ...requestFields]) {
+      if (!(field in this)) {
+        throw new Error(`Field ${field} is missing.`);
+      }
+    }
+
+    const inputAssignment = inputFields.join(', ');
+    const outputAssignment = requestFields.join(', ');
+    return `${inputAssignment} -> ${outputAssignment}`;
+  }
+
+  createForm({
+    assignment,
+    inputFields,
+    requestFields,
+    taskDescription,
+    fillInputs = true,
+    noneAsValidValue = false,
+    strict,
+  }: {
+    assignment?: string;
+    inputFields?: string[];
+    requestFields?: string[];
+    taskDescription?: string;
+    fillInputs?: boolean;
+    noneAsValidValue?: boolean;
+    strict?: boolean;
+  }): Form {
+    if (assignment) {
+      if (inputFields || requestFields) {
+        throw new Error('Cannot provide input/request fields with assignment.');
+      }
+    } else {
+      if (!inputFields || !requestFields) {
+        throw new Error('Provide inputFields and requestFields lists together.');
+      }
+    }
+
+    if (!assignment) {
+      assignment = this.parseAssignment(inputFields!, requestFields!);
+    }
+
+    return this.defaultFormTemplate.fromForm({
+      assignment,
+      form: this,
+      taskDescription,
+      fillInputs,
+      noneAsValidValue,
+      strict: strict ?? this.strictForm,
+    });
+  }
+
+  saveCompletedForm(form: Form, updateResults = false): void {
+    try {
+      form.checkIsCompleted('raise');
+    } catch (e) {
+      throw new Error(`Failed to add completed form. Error: ${e}`);
+    }
+
+    const reportFields = Object.keys(this);
+    for (const field of Object.keys(form)) {
+      if (!reportFields.includes(field)) {
+        throw new Error(
+          `The task does not match the report. Field ${field} in task assignment not found in report.`
+        );
+      }
+    }
+
+    this.completedTasks.include(form);
+    this.completedTaskAssignments[form.ln_id] = form.assignment;
+
+    if (updateResults) {
+      for (const field of form.requestFields) {
+        const fieldResult = (form as any)[field];
+        (this as any)[field] = fieldResult;
+      }
+    }
+  }
+
+  static fromFormTemplate(templateClass: typeof BaseForm, inputKwargs: Record<string, any> = {}): Report {
+    if (!(templateClass.prototype instanceof BaseForm)) {
+      throw new Error('Invalid form template. Must be a subclass of Form.');
+    }
+
+    const repTemplate = `report_for_${templateClass.prototype.templateName}`;
+    const reportObj = new Report({ templateName: repTemplate });
+
+    const baseReportFields = Object.keys(Report.prototype);
+
+    for (const [field, fieldInfo] of Object.entries(templateClass.prototype)) {
+      if (baseReportFields.includes(field)) continue;
+      if (!(field in reportObj)) {
+        (reportObj as any)[field] = fieldInfo;
+      }
+      if (field in inputKwargs) {
+        (reportObj as any)[field] = inputKwargs[field];
+      }
+    }
+
+    return reportObj;
+  }
+
+  static fromForm(form: BaseForm, fillInputs = true): Report {
+    if (!(form instanceof BaseForm)) {
+      throw new TypeError('Invalid form. Should be an instance of BaseForm.');
+    }
+
+    const reportTemplateName = `report_for_${form.templateName}`;
+    const reportObj = new Report({ templateName: reportTemplateName });
+
+    const baseReportFields = Object.keys(Report.prototype);
+
+    for (const [field, fieldInfo] of Object.entries(form)) {
+      if (baseReportFields.includes(field)) continue;
+      if (!(field in reportObj)) {
+        (reportObj as any)[field] = fieldInfo;
+      }
+      if (fillInputs) {
+        (reportObj as any)[field] = (form as any)[field];
+      }
+    }
+
+    return reportObj;
+  }
+}


### PR DESCRIPTION
Translate Python files under `src/core_py` to TypeScript and place them in appropriate directories under `src`.

* **Core Registry**
  - Add `src/core/_class_registry.ts` to translate `_class_registry.py` to TypeScript.
  - Implement class registry and file registry functionalities.

* **Action Management**
  - Add `src/core/action/action_manager.ts` to translate `action_manager.py` to TypeScript.
  - Implement action manager functionalities including tool registration and invocation.
  - Add `src/core/action/base.ts` to translate `base.py` to TypeScript.
  - Implement observable action functionalities.
  - Add `src/core/action/function_calling.ts` to translate `function_calling.py` to TypeScript.
  - Implement function calling functionalities.
  - Add `src/core/action/tool.ts` to translate `tool.py` to TypeScript.
  - Implement tool functionalities and function-to-tool conversion.

* **Communication**
  - Add `src/core/communication/action_request.ts` to translate `action_request.py` to TypeScript.
  - Implement action request functionalities.
  - Add `src/core/communication/action_response.ts` to translate `action_response.py` to TypeScript.
  - Implement action response functionalities.
  - Add `src/core/communication/assistant_response.ts` to translate `assistant_response.py` to TypeScript.
  - Implement assistant response functionalities.
  - Add `src/core/communication/instruction.ts` to translate `instruction.py` to TypeScript.
  - Implement instruction functionalities.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ohdearquant/lion-ts/pull/2?shareId=8a452dc6-e29c-47ab-9792-b0eef391ace4).